### PR TITLE
Stylistic fixes for CollateralPieChart

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,5 +6,6 @@ packageExtensions:
         optional: true
 
 pnpMode: loose
+checksumBehavior: update
 
 yarnPath: .yarn/releases/yarn-3.2.2.cjs

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,10 @@
-import { BigNumber } from '@ethersproject/bignumber'
-import { BigNumberMap, TransactionState } from './../types'
 import { getAddress } from '@ethersproject/address'
+import { BigNumber } from '@ethersproject/bignumber'
 import { JsonRpcSigner, Web3Provider } from '@ethersproject/providers'
 import { t } from '@lingui/macro'
 import { Contract } from 'ethers'
 import { parseEther } from 'ethers/lib/utils'
+import { BigNumberMap, TransactionState } from './../types'
 
 export const decimalPattern = /^[0-9]*[.]?[0-9]*$/i
 export const numberPattern = /^\d+$/
@@ -152,6 +152,12 @@ export function formatCurrency(value: number, decimals = 2): string {
     value
   )
 }
+
+export const formatPercentage = (value: number, decimals = 2): string =>
+  (value / 100).toLocaleString('en-US', {
+    style: 'percent',
+    maximumFractionDigits: decimals,
+  })
 
 // Utils for rable parsing
 export const formatCurrencyCell = ({ cell }: { cell: any }) =>

--- a/src/views/overview/components/CollateralPieChart.tsx
+++ b/src/views/overview/components/CollateralPieChart.tsx
@@ -1,6 +1,7 @@
 import TokenLogo from 'components/icons/TokenLogo'
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
 import { Box, BoxProps } from 'theme-ui'
+import { formatPercentage } from 'utils'
 
 interface ChartProps extends BoxProps {
   data: { name: string; value: number; color: string }[]
@@ -46,7 +47,10 @@ const CollateralChart = ({
             <Cell key={`cell-${index}`} fill={entry.color} />
           ))}
         </Pie>
-        <Tooltip />
+        <Tooltip
+          wrapperStyle={{ zIndex: 10 }}
+          formatter={(value) => formatPercentage(Number(value), 4)}
+        />
         {!isRSV && (
           <Pie
             dataKey="value"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8863,7 +8863,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
+  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Noticed a few quick fixes:

#### Before
<img width="433" alt="Screenshot 2023-02-24 at 11 26 59" src="https://user-images.githubusercontent.com/7811733/221095735-a15d97d1-e8ca-441f-bff0-9b69134d7b67.png">

#### After
<img width="450" alt="Screenshot 2023-02-24 at 11 48 00" src="https://user-images.githubusercontent.com/7811733/221095757-b56f0513-3b95-4b62-b2a0-6fd25212cc37.png">

#### Changes

1. `yarn install` currently fails without the checksum option I've added
2. Added z-index to the tooltip wrapper
3. Added percentage formatter to tooltip values
