### PR TITLE
feat: add max issuance/redemption throttle amounts

### DIFF
--- a/src/components/transaction-input/index.tsx
+++ b/src/components/transaction-input/index.tsx
@@ -1,4 +1,5 @@
 import { NumericalInput } from 'components'
+import Help from 'components/help'
 import { useAtom } from 'jotai'
 import { Box, BoxProps, Flex, Text } from 'theme-ui'
 import { formatCurrency } from 'utils'
@@ -9,8 +10,40 @@ export interface TransactionInputProps extends BoxProps {
   compact?: boolean
   amountAtom: any
   maxAmount: string
+  globalMaxAmount?: number
+  help?: string
   disabled?: boolean
   autoFocus?: boolean
+  hasThrottle?: boolean
+}
+
+interface MaxLabelProps {
+  text: string
+  compact: boolean
+  clickable: boolean
+  help?: string
+  handleClick: () => void
+}
+
+const MaxLabel = ({
+  text,
+  compact,
+  clickable,
+  help = '',
+  handleClick,
+}: MaxLabelProps) => {
+  return (
+    <Text
+      onClick={handleClick}
+      as={clickable ? 'a' : 'span'}
+      variant={clickable ? 'a' : 'legend'}
+      sx={{ display: 'block', fontSize: compact ? 1 : 2 }}
+      ml={'auto'}
+      mr={2}
+    >
+      {text} {!!help && <Help content={help} />}
+    </Text>
+  )
 }
 
 const TransactionInput = ({
@@ -18,24 +51,33 @@ const TransactionInput = ({
   placeholder = '',
   amountAtom,
   maxAmount,
+  globalMaxAmount = 0,
+  help = '',
   disabled = false,
-  compact = false,
+  compact = true,
   autoFocus = false,
+  hasThrottle = false,
   ...props
 }: TransactionInputProps) => {
   const [amount, setAmount] = useAtom(amountAtom)
 
   const maxLabel = (
-    <Text
-      onClick={() => setAmount(maxAmount)}
-      as="a"
-      variant="a"
-      sx={{ display: 'block', fontSize: compact ? 1 : 2 }}
-      ml={'auto'}
-      mr={2}
-    >
-      Max: {formatCurrency(+maxAmount, 5)}
-    </Text>
+    <MaxLabel
+      text={`Max: ${formatCurrency(+maxAmount, 5)}`}
+      handleClick={() => setAmount(maxAmount)}
+      clickable={true}
+      compact
+    />
+  )
+
+  const throttleLabel = (
+    <MaxLabel
+      text={`Global Max: ${formatCurrency(+globalMaxAmount, 2)}`}
+      handleClick={() => {}}
+      help={help}
+      clickable={false}
+      compact
+    />
   )
 
   return (
@@ -53,7 +95,11 @@ const TransactionInput = ({
         onChange={setAmount}
         autoFocus={autoFocus}
       />
-      {!compact && <Flex mt={2}>{maxLabel}</Flex>}
+      {!compact ? (
+        <Flex mt={2}>{maxLabel}</Flex>
+      ) : (
+        !!globalMaxAmount && <Flex mt={2}>{throttleLabel}</Flex>
+      )}
     </Box>
   )
 }

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -227,6 +227,8 @@ export const rsrPriceAtom = atom(0)
 export const gasPriceAtom = atom(0)
 export const rTokenPriceAtom = atom(0)
 export const rsrExchangeRateAtom = atom(1)
+export const maxIssuanceAtom = atom(0)
+export const maxRedemptionAtom = atom(0)
 export const rTokenTotalSupplyAtom = atom('')
 export const stRSRSupplyAtom = atom('')
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -191,6 +191,8 @@ export interface ReserveToken extends Token {
   unlisted?: boolean // Mark if the token is not listed
   mandate?: string
   meta?: RTokenMeta
+  redemptionAvailable?: number
+  issuanceAvailable?: number
 }
 
 export interface AccountToken {

--- a/src/views/issuance/components/issue/IssueInput.tsx
+++ b/src/views/issuance/components/issue/IssueInput.tsx
@@ -4,18 +4,21 @@ import TransactionInput, {
 } from 'components/transaction-input'
 import { formatEther } from 'ethers/lib/utils'
 import { useAtomValue } from 'jotai'
-import { isRTokenDisabledAtom } from 'state/atoms'
+import { isRTokenDisabledAtom, maxIssuanceAtom } from 'state/atoms'
 import { issueAmountAtom, maxIssuableAtom } from '../../atoms'
 
 const IssueInput = (props: Partial<TransactionInputProps>) => {
   const issuableAmount = useAtomValue(maxIssuableAtom)
   const isTokenDisabled = useAtomValue(isRTokenDisabledAtom)
+  const issuanceAvailable = useAtomValue(maxIssuanceAtom)
 
   return (
     <TransactionInput
       placeholder={t`Mint amount`}
       amountAtom={issueAmountAtom}
       maxAmount={formatEther(issuableAmount)}
+      help={t`Each RToken can have an issuance throttle to limit the amount of extractable value in the case of an attack. After a large isuance, the issuance limit recharges linearly to the defined maximum at a defined speed of recharge`}
+      globalMaxAmount={issuanceAvailable}
       disabled={isTokenDisabled}
       {...props}
     />

--- a/src/views/issuance/components/redeem/RedeemInput.tsx
+++ b/src/views/issuance/components/redeem/RedeemInput.tsx
@@ -3,7 +3,11 @@ import TransactionInput, {
   TransactionInputProps,
 } from 'components/transaction-input'
 import { atom, useAtomValue } from 'jotai'
-import { rTokenBalanceAtom, rTokenStatusAtom } from 'state/atoms'
+import {
+  maxRedemptionAtom,
+  rTokenBalanceAtom,
+  rTokenStatusAtom,
+} from 'state/atoms'
 import { redeemAmountAtom } from 'views/issuance/atoms'
 
 const isTokenFrozenAtom = atom((get) => {
@@ -15,6 +19,7 @@ const isTokenFrozenAtom = atom((get) => {
 const RedeemInput = (props: Partial<TransactionInputProps>) => {
   const max = useAtomValue(rTokenBalanceAtom)
   const isTokenFrozen = useAtomValue(isTokenFrozenAtom)
+  const redemptionAvailable = useAtomValue(maxRedemptionAtom)
 
   return (
     <TransactionInput
@@ -22,6 +27,8 @@ const RedeemInput = (props: Partial<TransactionInputProps>) => {
       placeholder={t`Redeem amount`}
       amountAtom={redeemAmountAtom}
       maxAmount={max.balance}
+      help={t`Each RToken can have a redemption throttle to limit the amount of extractable value in the case of an attack. After a large redemption, the redemption limit recharges linearly to the defined maximum at a defined speed of recharge.`}
+      globalMaxAmount={redemptionAvailable}
       disabled={isTokenFrozen}
       {...props}
     />


### PR DESCRIPTION
Add maximum issuance and redemption numbers to the UI along with a tooltip explaining these numbers 
![image](https://user-images.githubusercontent.com/71284258/227041712-6078c030-85ae-4b0c-a947-f562a865bd08.png)
