### PR TITLE
Use swapRegistered for collateral when appropriate

### DIFF
--- a/src/components/rtoken-setup/atoms.ts
+++ b/src/components/rtoken-setup/atoms.ts
@@ -8,6 +8,7 @@ export interface Collateral {
   address: string
   targetUnit: string
   rewardToken?: string
+  collateralAddress?: string
   custom?: boolean
 }
 

--- a/src/utils/plugins/mainnet.ts
+++ b/src/utils/plugins/mainnet.ts
@@ -171,7 +171,7 @@ const plugins: CollateralPlugin[] = [
     referenceUnit: 'DAI',
     collateralToken: 'cDAI',
     description: '',
-    collateralAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+    collateralAddress: underlyingCollateralAddresses.cDAI,
     rewardToken: COMPOUND_ADDRESS[ChainId.Mainnet],
   },
   {
@@ -182,7 +182,7 @@ const plugins: CollateralPlugin[] = [
     referenceUnit: 'USDC',
     collateralToken: 'cUSDC',
     description: '',
-    collateralAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    collateralAddress: underlyingCollateralAddresses.cUSDC,
     rewardToken: COMPOUND_ADDRESS[ChainId.Mainnet],
   },
   {
@@ -193,7 +193,7 @@ const plugins: CollateralPlugin[] = [
     referenceUnit: 'USDT',
     collateralToken: 'aUSDT',
     description: '',
-    collateralAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    collateralAddress: underlyingCollateralAddresses.cUSDT,
     rewardToken: COMPOUND_ADDRESS[ChainId.Mainnet],
   },
   {
@@ -204,7 +204,7 @@ const plugins: CollateralPlugin[] = [
     referenceUnit: 'WBTC',
     collateralToken: 'cWBTC',
     description: '',
-    collateralAddress: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+    collateralAddress: underlyingCollateralAddresses.cWBTC,
     rewardToken: COMPOUND_ADDRESS[ChainId.Mainnet],
   },
   {
@@ -215,7 +215,7 @@ const plugins: CollateralPlugin[] = [
     referenceUnit: 'ETH',
     collateralToken: 'cETH',
     description: '',
-    collateralAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    collateralAddress: underlyingCollateralAddresses.cETH,
     rewardToken: COMPOUND_ADDRESS[ChainId.Mainnet],
   },
   {

--- a/src/views/governance/components/ProposalDetailPreview.tsx
+++ b/src/views/governance/components/ProposalDetailPreview.tsx
@@ -69,9 +69,6 @@ const ProposalDetail = ({ addresses, calldatas, ...props }: Props) => {
   const interfaceMap = useAtomValue(interfaceMapAtom)
   const [parse] = parseCallDatas(addresses, calldatas, interfaceMap)
 
-  console.log('interfaceMap', interfaceMap)
-  console.log('changes', addresses)
-
   return (
     <Box>
       {Object.keys(parse).map((address, index) => (

--- a/src/views/governance/views/proposal/updater.tsx
+++ b/src/views/governance/views/proposal/updater.tsx
@@ -160,6 +160,7 @@ export const ChangesUpdater = () => {
       )
     }
   }, [
+    isBasketValid,
     isNewBasket,
     backupChanges,
     revenueChanges,


### PR DESCRIPTION
This error was reported by a user when trying to switch eUSD basket  

> I tried building a primary basket proposal using Register today, and thanks to all that you've taught me, I spotted a few errors in what it generated -- it used register instead of swapRegistered with the Asset Registry even though there are already collateral plugins registered for cUSDC and saUSDC (which i was putting in the basket), and this one I'm guessing is wrong, it built the array of assets for setPrimeBasket using the collateral plug-in addresses instead of the erc20 contract addresses.

This is corrected by checking whether the underlying asset had already been registered, and if so, call swapRegistered. 