### PR TITLE
Bug Fixes - duplicate transactions and accurate APYs

### DIFF
--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -223,6 +223,8 @@ export const collateralYieldAtom = atom<{ [x: string]: number }>({
 
 export const ethPriceAtom = atom(1)
 export const rsrPriceAtom = atom(0)
+export const btcPriceAtom = atom(0)
+export const eurPriceAtom = atom(0)
 export const gasPriceAtom = atom(0)
 export const rTokenPriceAtom = atom(0)
 export const rsrExchangeRateAtom = atom(1)

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -114,6 +114,18 @@ export const EUSD_ADDRESS: AddressMap = {
   [ChainId.Hardhat]: '0xA0d69E286B938e21CBf7E51D71F6A4c8918f482F',
 }
 
+export const WBTC_ADDRESS: AddressMap = {
+  [ChainId.Mainnet]: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+  [ChainId.Goerli]: '0xC04B0d3107736C32e19F1c62b2aF67BE61d63a05',
+  [ChainId.Hardhat]: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+}
+
+export const EURT_ADDRESS: AddressMap = {
+  [ChainId.Mainnet]: '0xc581b735a1688071a1746c968e0798d642ede491',
+  [ChainId.Goerli]: '0xc581b735a1688071a1746c968e0798d642ede491',
+  [ChainId.Hardhat]: '0xc581b735a1688071a1746c968e0798d642ede491',
+}
+
 // Fixed tokens used in the rtoken selector screen and dashboard
 export const DEFAULT_TOKENS = {
   [ChainId.Mainnet]: [

--- a/src/views/overview/components/RecentTransactions.tsx
+++ b/src/views/overview/components/RecentTransactions.tsx
@@ -28,13 +28,20 @@ const RecentTransactions = () => {
   const { data } = useQuery(recentTxsQuery, {
     tokenId: rToken?.address.toLowerCase() ?? '',
   })
+
   const txs = useMemo(() => {
     if (!data?.entries) {
       return []
     }
 
     // TODO: Parse type depending on lang
-    return data.entries.map((tx: any) => ({
+    const uniqueEntries = Object.values(
+      data.entries.reduce(
+        (acc: any, obj: any) => ({ ...acc, [obj.hash]: obj }),
+        {}
+      )
+    )
+    return uniqueEntries.map((tx: any) => ({
       ...tx,
       amount: Number(formatEther(tx.amount)),
     }))


### PR DESCRIPTION
closes #41 and #44 

- (#41) 
  - The filter for unique tx hashes can be reverted if the fix is made in The Graph instead
- (#44)
  - The fix normalizes the USD value of the collateral vs the APY in the basket, based on the target units (BTC, ETH, USD, etc)  
  - Sushiswap, Uniswap and Chainlink oracles were insufficient to get price data (or were otherwise clunky to obtain), so Coingecko is relied on for pricing instead