### PR TITLE
Feat: consolidate voting/delegation into single button

### DIFF
--- a/src/views/governance/components/AccountVotes.tsx
+++ b/src/views/governance/components/AccountVotes.tsx
@@ -57,7 +57,7 @@ const AccountVotes = () => {
             <Trans>Delegate</Trans>
           </SmallButton>
           <Text ml={3} variant="legend" as="span">
-            <Trans>Voting Power: </Trans>
+            <Trans>Balance: </Trans>
           </Text>{' '}
           <Text variant="legend">{stRsrBalance.balance}</Text>
         </Box>

--- a/src/views/governance/components/AccountVotes.tsx
+++ b/src/views/governance/components/AccountVotes.tsx
@@ -5,7 +5,9 @@ import { SmallButton } from 'components/button'
 import GoTo from 'components/button/GoTo'
 import { useContractCall } from 'hooks/useCall'
 import useRToken from 'hooks/useRToken'
+import { useAtomValue } from 'jotai'
 import { useState } from 'react'
+import { stRsrBalanceAtom } from 'state/atoms'
 import { Box, Text, Image } from 'theme-ui'
 import { shortenAddress } from 'utils'
 import { ZERO_ADDRESS } from 'utils/addresses'
@@ -15,6 +17,7 @@ import DelegateModal from './DelegateModal'
 const AccountVotes = () => {
   const { account } = useWeb3React()
   const rToken = useRToken()
+  const stRsrBalance = useAtomValue(stRsrBalanceAtom)
   const [isVisible, setVisible] = useState(false)
   const { value = [] } =
     useContractCall(
@@ -53,6 +56,10 @@ const AccountVotes = () => {
           <SmallButton mt={3} variant="muted" onClick={handleDelegate}>
             <Trans>Delegate</Trans>
           </SmallButton>
+          <Text ml={3} variant="legend" as="span">
+            <Trans>Voting Power: </Trans>
+          </Text>{' '}
+          <Text variant="legend">{stRsrBalance.balance}</Text>
         </Box>
       ) : (
         <Box variant="layout.verticalAlign">

--- a/src/views/governance/views/proposal-detail/components/ProposalVote.tsx
+++ b/src/views/governance/views/proposal-detail/components/ProposalVote.tsx
@@ -19,7 +19,7 @@ const ProposalVote = (props: BoxProps) => {
   const { account } = useWeb3React()
   const rToken = useRToken()
 
-  const [isVisible, setVisible] = useState(false)
+  const [isVoteVisible, setVoteVisible] = useState(false)
   const [isDelegateVisible, setDelegateVisible] = useState(false)
   const { state } = useAtomValue(getProposalStateAtom)
   const { votePower = '0.0', vote } = useAtomValue(accountVotesAtom)
@@ -35,10 +35,15 @@ const ProposalVote = (props: BoxProps) => {
           args: [account],
         }
     ) ?? {}
+
   const hasNoDelegates = !value[0] || value[0] === ZERO_ADDRESS
 
   const hasUndelegatedBalance =
-    !!account && votePower && !Number(votePower) && !!Number(balance)
+    !!account &&
+    votePower &&
+    !Number(votePower) &&
+    !!Number(balance) &&
+    hasNoDelegates
 
   return (
     <Box variant="layout.borderBox" sx={{ textAlign: 'center' }} {...props}>
@@ -50,7 +55,7 @@ const ProposalVote = (props: BoxProps) => {
       </Text>
       {hasUndelegatedBalance ? (
         <Button sx={{ width: '100%' }} onClick={() => setDelegateVisible(true)}>
-          <Trans>Please delegate your voting power</Trans>
+          <Trans>Delegate voting power for future votes</Trans>
         </Button>
       ) : (
         <Button
@@ -73,7 +78,7 @@ const ProposalVote = (props: BoxProps) => {
           <Trans>Please connect your wallet</Trans>
         </Text>
       )}
-      {isVisible && <VoteModal onClose={() => setVisible(false)} />}
+      {isVoteVisible && <VoteModal onClose={() => setVoteVisible(false)} />}
       {isDelegateVisible && (
         <DelegateModal
           delegated={!hasNoDelegates}

--- a/src/views/governance/views/proposal-detail/components/ProposalVote.tsx
+++ b/src/views/governance/views/proposal-detail/components/ProposalVote.tsx
@@ -1,21 +1,44 @@
 import { Trans } from '@lingui/macro'
 import { useWeb3React } from '@web3-react/core'
+import { stRSRVotesInterface } from 'abis'
+import { useContractCall } from 'hooks/useCall'
+import useRToken from 'hooks/useRToken'
 import { useAtomValue } from 'jotai'
 import { useState } from 'react'
 import { stRsrBalanceAtom } from 'state/atoms'
 import { Box, BoxProps, Button, Text } from 'theme-ui'
 import { formatCurrency } from 'utils'
+import { ZERO_ADDRESS } from 'utils/addresses'
 import { PROPOSAL_STATES } from 'utils/constants'
+import DelegateModal from 'views/governance/components/DelegateModal'
 import { accountVotesAtom, getProposalStateAtom } from '../atom'
 import VoteModal from './VoteModal'
 
 // TODO: Validate voting power first?
 const ProposalVote = (props: BoxProps) => {
   const { account } = useWeb3React()
+  const rToken = useRToken()
+
   const [isVisible, setVisible] = useState(false)
+  const [isDelegateVisible, setDelegateVisible] = useState(false)
   const { state } = useAtomValue(getProposalStateAtom)
   const { votePower = '0.0', vote } = useAtomValue(accountVotesAtom)
   const { balance } = useAtomValue(stRsrBalanceAtom)
+
+  const { value = [] } =
+    useContractCall(
+      account &&
+        rToken?.stToken?.address && {
+          abi: stRSRVotesInterface,
+          address: rToken.stToken.address,
+          method: 'delegates',
+          args: [account],
+        }
+    ) ?? {}
+  const hasNoDelegates = !value[0] || value[0] === ZERO_ADDRESS
+
+  const hasUndelegatedBalance =
+    !!account && votePower && !Number(votePower) && !!Number(balance)
 
   return (
     <Box variant="layout.borderBox" sx={{ textAlign: 'center' }} {...props}>
@@ -25,30 +48,38 @@ const ProposalVote = (props: BoxProps) => {
       <Text variant="title" mt={1} mb={3}>
         {formatCurrency(votePower ? +votePower : 0)}
       </Text>
-      <Button
-        disabled={
-          !account ||
-          !!vote ||
-          state === PROPOSAL_STATES.PENDING ||
-          !votePower ||
-          votePower === '0.0'
-        }
-        sx={{ width: '100%' }}
-        onClick={() => setVisible(true)}
-      >
-        {vote ? `You voted "${vote}"` : <Trans>Vote on-chain</Trans>}
-      </Button>
+      {hasUndelegatedBalance ? (
+        <Button sx={{ width: '100%' }} onClick={() => setDelegateVisible(true)}>
+          <Trans>Please delegate your voting power</Trans>
+        </Button>
+      ) : (
+        <Button
+          disabled={
+            !account ||
+            !!vote ||
+            state === PROPOSAL_STATES.PENDING ||
+            !votePower ||
+            votePower === '0.0'
+          }
+          sx={{ width: '100%' }}
+          onClick={() => setDelegateVisible(true)}
+        >
+          {vote ? `You voted "${vote}"` : <Trans>Vote on-chain</Trans>}
+        </Button>
+      )}
+
       {!account && (
         <Text mt={3} sx={{ display: 'block', color: 'warning' }}>
           <Trans>Please connect your wallet</Trans>
         </Text>
       )}
-      {!!account && votePower && !Number(votePower) && !!Number(balance) && (
-        <Text mt={3} sx={{ display: 'block', color: 'warning' }}>
-          <Trans>Please delegate your voting power</Trans>
-        </Text>
-      )}
       {isVisible && <VoteModal onClose={() => setVisible(false)} />}
+      {isDelegateVisible && (
+        <DelegateModal
+          delegated={!hasNoDelegates}
+          onClose={() => setDelegateVisible(false)}
+        />
+      )}
     </Box>
   )
 }


### PR DESCRIPTION
Closes #52 

3 different states are now represented by a single button

1. When user has no voting power available  
<img width="459" alt="image" src="https://user-images.githubusercontent.com/71284258/228709746-2714fa5e-6f32-4cb1-8b0b-767c9b36dce7.png">

2. User has undelegated voting power (same conditions for showing the former "Please delegate your voting power" message). Clicking the button will show the `DelegateModal`.

- After delegating, the user will see the screen in 1) above because it is either past the proposal snapshot or they're on a proposal for which voting hasn't started yet
 
<img width="468" alt="image" src="https://user-images.githubusercontent.com/71284258/228712484-e90838a7-82e8-4b5d-ab81-5469abee517d.png">

3. User has active voting power for this proposal - this is unchanged from before
<img width="334" alt="image" src="https://user-images.githubusercontent.com/71284258/228713033-02a3c732-2c4d-4eab-9cdb-32b2bb54eee1.png">
