### PR TITLE
feat: add e2e test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ REACT_APP_ONE_INCH_URLS=https://cold-mouse-7d43.mig2151.workers.dev,\
                         https://blue-cake-3548.mig2151.workers.dev,\
                         https://bitter-tree-ed5a.mig2151.workers.dev,\
                         https://square-morning-0921.mig2151.workers.dev/
+
+# End to end test
+GUARDIAN_UI_ALCHEMY_API_KEY=
+GUARDIAN_UI_ANVIL_FLAGS="--compute-units-per-second 100 --fork-retry-backoff 5000"

--- a/.github/workflows/guardian.yml
+++ b/.github/workflows/guardian.yml
@@ -29,6 +29,7 @@ jobs:
           yarn test:e2e
         env:
           GUARDIAN_UI_ALCHEMY_API_KEY: ${{ secrets.GUARDIAN_UI_ALCHEMY_API_KEY }}
+          CI: true
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/guardian.yml
+++ b/.github/workflows/guardian.yml
@@ -1,14 +1,17 @@
 name: Guardian Tests
+
 on:
   push:
     branches: [main, development]
   pull_request:
     branches: [main, development]
+
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/guardian.yml
+++ b/.github/workflows/guardian.yml
@@ -1,0 +1,40 @@
+name: Guardian Tests
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Install dependencies
+        run: yarn
+      - name: Install playwright browsers
+        run: yarn playwright install --with-deps
+      - name: Run Guardian tests
+        run: |
+          yarn tsx tests/getRTokens.ts > tests/RTokens.json
+          yarn test:gui
+        env:
+          GUARDIAN_UI_ALCHEMY_API_KEY: ${{ secrets.GUARDIAN_UI_ALCHEMY_API_KEY }}
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 30

--- a/.github/workflows/guardian.yml
+++ b/.github/workflows/guardian.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Guardian tests
         run: |
           yarn tsx tests/getRTokens.ts > tests/RTokens.json
-          yarn test:gui
+          yarn test:e2e
         env:
           GUARDIAN_UI_ALCHEMY_API_KEY: ${{ secrets.GUARDIAN_UI_ALCHEMY_API_KEY }}
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/guardian.yml
+++ b/.github/workflows/guardian.yml
@@ -30,6 +30,15 @@ jobs:
         env:
           GUARDIAN_UI_ALCHEMY_API_KEY: ${{ secrets.GUARDIAN_UI_ALCHEMY_API_KEY }}
           CI: true
+          REACT_APP_SUBGRAPH_URL: https://api.thegraph.com/subgraphs/name/lcamargof/reserve
+          REACT_APP_CHAIN_ID: 1
+          REACT_APP_RPAY_FEED: feed.rpay.app
+          REACT_APP_ONE_INCH_URLS: |
+            https://cold-mouse-7d43.mig2151.workers.dev,\
+            https://blue-cake-3548.mig2151.workers.dev,\
+            https://bitter-tree-ed5a.mig2151.workers.dev,\
+            https://square-morning-0921.mig2151.workers.dev/
+          GUARDIAN_UI_ANVIL_FLAGS: "--compute-units-per-second 100 --fork-retry-backoff 5000"
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ yarn-error.log*
 
 # Visual Studio Code
 .vscode
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/
+tests/RTokens.json

--- a/README.md
+++ b/README.md
@@ -24,6 +24,38 @@ yarn start
 
 Please go to [this repository](https://github.com/lc-labs/rtokens) and create a pull request with the token you want to add following the instructions of the README.
 
+## Run end-to-end test
+
+You need to install [Anvil](https://github.com/foundry-rs/foundry/blob/master/anvil/README.md).
+
+Setup `playwright` headless browsers using the following command:
+
+```
+yarn playwright install --with-deps
+```
+
+Then run the test:
+
+```
+# Generate the RToken data (collaterals, balance slot & allowance slot)
+yarn tsx tests/getRTokens.ts > tests/RTokens.json
+
+# Run e2e for AAVE Wrapper
+yarn playwright test tests/AAVEWrapper.gui.ts --trace on
+
+# Run e2e for Convex Staking Wrapper
+yarn playwright test tests/ConvexStakingWrapper.gui.ts --trace on
+
+# Run the test for all RToken
+yarn playwright test tests/RToken.gui.ts --trace on
+```
+
+Use the following command to view the test trace:
+
+```
+yarn playwright show-trace test-results/RToken.gui.ts-Mint-RToken-0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8-chromium/trace.zip
+```
+
 ## Contributing
 
 Fork this repository and create a pull request against the `development` branch

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "test": "react-scripts test",
     "translations": "lingui extract --clean && lingui compile",
-    "postinstall": "npx patch-package"
+    "postinstall": "npx patch-package",
+    "test:e2e": "playwright test"
   },
   "engines": {
     "node": ">=18.13.0"
@@ -86,8 +87,10 @@
     ]
   },
   "devDependencies": {
+    "@guardianui/test": "^1.0.4",
     "@lingui/cli": "^3.13.3",
     "@lingui/macro": "^3.13.3",
+    "@playwright/test": "1.33.0",
     "@react-spring/types": "^9.4.5",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.0.0",
@@ -99,11 +102,14 @@
     "@types/react-dom": "18.0.0",
     "@types/react-table": "^7.7.10",
     "@types/uuid": "^8.3.4",
+    "@viem/anvil": "^0.0.6",
     "babel-plugin-macros": "^3.1.0",
     "babel-preset-react-app": "^10.0.1",
+    "dotenv": "^16.3.1",
     "patch-package": "^7.0.0",
     "prettier": "^2.3.2",
     "source-map-explorer": "^2.5.2",
+    "tsx": "^3.12.7",
     "typechain": "^8.1.0",
     "typescript": "^4.6.2"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { PlaywrightTestConfig, devices } from '@playwright/test'
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  testMatch: '*.gui.ts',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [['html', { open: 'never' }]],
+  timeout: 300_000,
+  use: {
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--disable-web-security'],
+        },
+      },
+    },
+  ],
+
+  webServer: {
+    command: 'yarn start',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+}
+
+export default config

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,6 +29,7 @@ const config: PlaywrightTestConfig = {
     command: 'yarn start',
     url: 'http://127.0.0.1:3000',
     reuseExistingServer: !process.env.CI,
+    timeout: 120_000
   },
 }
 

--- a/src/hooks/useTransactionCost.ts
+++ b/src/hooks/useTransactionCost.ts
@@ -38,9 +38,18 @@ export const useTransactionGasFee = (
               account
             )
 
-            const estimate = await contract.estimateGas[tx.call.method](
-              ...tx.call.args
+            // NOTE:
+            // contract.estimateGas[tx.call.method]() doesn't include signer
+            // address in the RPC call
+            const data = contract.interface.encodeFunctionData(
+              tx.call.method,
+              tx.call.args
             )
+            const estimate = await contract.signer.estimateGas({
+              to: tx.call.address,
+              data,
+            })
+
             totalFee += estimate.toNumber()
             return estimate.toNumber()
           })

--- a/src/views/issuance/components/issue/ConvexCollateralModal.tsx
+++ b/src/views/issuance/components/issue/ConvexCollateralModal.tsx
@@ -15,7 +15,7 @@ import { useTransactions } from 'state/web3/hooks/useTransactions'
 import { promiseMulticall } from 'state/web3/lib/multicall'
 import { Box, Divider, Flex, Link, Text } from 'theme-ui'
 import { BigNumberMap, TransactionState } from 'types'
-import { formatCurrency, getTransactionWithGasLimit, hasAllowance } from 'utils'
+import { formatCurrency, hasAllowance } from 'utils'
 import { CVX_ADDRESS } from 'utils/addresses'
 import { ChainId } from 'utils/chains'
 import { TRANSACTION_STATUS } from 'utils/constants'
@@ -85,27 +85,21 @@ const ConvexCollateralModal = ({
       for (const plugin of valids) {
         const amount = formState[plugin.address].value
         if (activeMode == ConvexMode.DEPOSIT) {
-          approvalTxs.push(
-            getTransactionWithGasLimit(
-              {
-                id: uuid(),
-                description: t`Approve ${plugin.symbol}`,
-                status: TRANSACTION_STATUS.PENDING,
-                value: amount,
-                call: {
-                  abi: 'erc20',
-                  address: plugin.collateralAddress,
-                  method: 'approve',
-                  args: [
-                    plugin.depositContract,
-                    parseUnits(amount, plugin.collateralDecimals || 18),
-                  ],
-                },
-              },
-              65_000,
-              0
-            )
-          )
+          approvalTxs.push({
+            id: uuid(),
+            description: t`Approve ${plugin.symbol}`,
+            status: TRANSACTION_STATUS.PENDING,
+            value: amount,
+            call: {
+              abi: 'erc20',
+              address: plugin.collateralAddress,
+              method: 'approve',
+              args: [
+                plugin.depositContract,
+                parseUnits(amount, plugin.collateralDecimals || 18),
+              ],
+            },
+          })
         }
         depositTxs.push({
           id: '',

--- a/src/views/issuance/components/issue/WrapCollateralModal.tsx
+++ b/src/views/issuance/components/issue/WrapCollateralModal.tsx
@@ -73,34 +73,28 @@ const WrapCollateralModal = ({
 
       for (const plugin of valids) {
         const amount = formState[plugin.address].value
-        approvalTxs.push(
-          getTransactionWithGasLimit(
-            {
-              id: uuid(),
-              description: t`Approve ${plugin.symbol}`,
-              status: TRANSACTION_STATUS.PENDING,
-              value: amount,
-              call: {
-                abi: 'erc20',
-                address: fromUnderlying
-                  ? (plugin.underlyingToken as string)
-                  : plugin.collateralAddress,
-                method: 'approve',
-                args: [
-                  plugin.depositContract,
-                  parseUnits(
-                    amount,
-                    fromUnderlying
-                      ? plugin.decimals
-                      : plugin.collateralDecimals || 18
-                  ),
-                ],
-              },
-            },
-            65_000,
-            0
-          )
-        )
+        approvalTxs.push({
+          id: uuid(),
+          description: t`Approve ${plugin.symbol}`,
+          status: TRANSACTION_STATUS.PENDING,
+          value: amount,
+          call: {
+            abi: 'erc20',
+            address: fromUnderlying
+              ? (plugin.underlyingToken as string)
+              : plugin.collateralAddress,
+            method: 'approve',
+            args: [
+              plugin.depositContract,
+              parseUnits(
+                amount,
+                fromUnderlying
+                  ? plugin.decimals
+                  : plugin.collateralDecimals || 18
+              ),
+            ],
+          },
+        })
 
         depositTxs.push({
           id: '',

--- a/tests/AAVEWrapper.gui.ts
+++ b/tests/AAVEWrapper.gui.ts
@@ -1,0 +1,98 @@
+import { test } from '@guardianui/test'
+import { setBalanceAtSlot } from './utils'
+
+test('Wrap Token to saToken', async ({ page, gui }) => {
+  // Fork Mainnet
+  await gui.initializeChain(1, 17586536)
+
+  // Go to eUSDC mint page
+  await page.goto(
+    'http://localhost:3000/#/issuance?token=0xA0d69E286B938e21CBf7E51D71F6A4c8918f482F'
+  )
+
+  // Block unnecessary http requests to speed up the tests
+  await page.route('**/*.{png,jpg,jpeg,webp}', (route) => route.abort())
+  await page.route(/(analytics|font|thegraph)/, (route) => route.abort())
+
+  // Mock balances
+  await gui.setEthBalance('100000000000000000000000')
+
+  await setBalanceAtSlot({
+    token: '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+    slotNumber: '2',
+    value: '1000000000000000000000000',
+    gui,
+  })
+  await setBalanceAtSlot({
+    token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+    slotNumber: '9',
+    value: '1000000000000',
+    gui,
+  })
+  await setBalanceAtSlot({
+    token: '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+    slotNumber: '2',
+    value: '1000000000000',
+    gui,
+  })
+
+  // Wrap DAI to saDAI
+  await page
+    .getByRole('button', { name: 'Wrap AAVE tokens', exact: true })
+    .click()
+  await page.getByText('Max: 1,000,000').nth(0).click({ timeout: 90_000 })
+  await page.getByText('Estimated gas cost:$').waitFor({ timeout: 90_000 })
+  await gui.validateContractInteraction(
+    'div:has-text("Approve") >> button >> nth=1',
+    '0xf6147b4b44ae6240f7955803b2fd5e15c77bd7ea'
+  )
+  await gui.validateContractInteraction(
+    'button >> span:has-text("Wrap tokens") >> nth=0',
+    '0xf6147b4b44ae6240f7955803b2fd5e15c77bd7ea'
+  )
+  await page
+    .locator('reach-portal')
+    .filter({ hasText: 'Transactions signed!' })
+    .locator('button')
+    .click()
+
+  // Wrap USDC to saUSDC
+  await page
+    .getByRole('button', { name: 'Wrap AAVE tokens', exact: true })
+    .click()
+  await page.getByText('Max: 1,000,000').nth(0).click({ timeout: 90_000 })
+  await page.getByText('Estimated gas cost:$').waitFor({ timeout: 90_000 })
+  await gui.validateContractInteraction(
+    'div:has-text("Approve") >> button >> nth=1',
+    '0x60c384e226b120d93f3e0f4c502957b2b9c32b15'
+  )
+  await gui.validateContractInteraction(
+    'button >> span:has-text("Wrap tokens") >> nth=0',
+    '0x60c384e226b120d93f3e0f4c502957b2b9c32b15'
+  )
+  await page
+    .locator('reach-portal')
+    .filter({ hasText: 'Transactions signed!' })
+    .locator('button')
+    .click()
+
+  // Wrap USDT to saUSDT
+  await page
+    .getByRole('button', { name: 'Wrap AAVE tokens', exact: true })
+    .click()
+  await page.getByText('Max: 1,000,000').nth(0).click({ timeout: 90_000 })
+  await page.getByText('Estimated gas cost:$').waitFor({ timeout: 90_000 })
+  await gui.validateContractInteraction(
+    'div:has-text("Approve") >> button >> nth=1',
+    '0x21fe646d1ed0733336f2d4d9b2fe67790a6099d9'
+  )
+  await gui.validateContractInteraction(
+    'button >> span:has-text("Wrap tokens") >> nth=0',
+    '0x21fe646d1ed0733336f2d4d9b2fe67790a6099d9'
+  )
+  await page
+    .locator('reach-portal')
+    .filter({ hasText: 'Transactions signed!' })
+    .locator('button')
+    .click()
+})

--- a/tests/ConvexStakingWrapper.gui.ts
+++ b/tests/ConvexStakingWrapper.gui.ts
@@ -1,0 +1,70 @@
+import { test } from '@guardianui/test'
+import { setBalanceAtSlot } from './utils'
+
+test('Wrap Convex Staking Token', async ({ page, gui }) => {
+  // Fork Mainnet
+  await gui.initializeChain(1, 17586536)
+
+  // Go to eUSDC mint page
+  await page.goto(
+    'http://localhost:3000/#/issuance?token=0xaCdf0DBA4B9839b96221a8487e9ca660a48212be'
+  )
+
+  // Block unnecessary http requests to speed up the tests
+  await page.route('**/*.{png,jpg,jpeg,webp}', (route) => route.abort())
+  await page.route(/(analytics|font|thegraph)/, (route) => route.abort())
+
+  // Mock balances
+  await gui.setEthBalance('100000000000000000000000')
+
+  await setBalanceAtSlot({
+    token: '0x8e074d44aabc1b3b4406fe03da7cef787ea85938', // cvxeUSD3CRV-f
+    slotNumber: '0',
+    value: '10000000000000000000000',
+    gui,
+  })
+  await setBalanceAtSlot({
+    token: '0xabb54222c2b77158cc975a2b715a3d703c256f05', // cvxMIM-3LP3CRV-f
+    slotNumber: '0',
+    value: '10000000000000000000000',
+    gui,
+  })
+
+  await page
+    .getByRole('button', { name: 'Wrap/unwrap Convex LP tokens', exact: true })
+    .click()
+  await page.getByText('Max: 10,000').nth(0).click({ timeout: 60_000 })
+  await page.getByText('Estimated gas cost:$').waitFor({ timeout: 60_000 })
+  await gui.validateContractInteraction(
+    'div:has-text("Approve") >> button >> nth=1',
+    '0xbf2fbeecc974a171e319b6f92d8f1d042c6f1ac3'
+  )
+  await gui.validateContractInteraction(
+    'button >> span:has-text("Wrap tokens") >> nth=0',
+    '0xbf2fbeecc974a171e319b6f92d8f1d042c6f1ac3'
+  )
+  await page
+    .locator('reach-portal')
+    .filter({ hasText: 'Transactions signed!' })
+    .locator('button')
+    .click()
+
+  await page
+    .getByRole('button', { name: 'Wrap/unwrap Convex LP tokens', exact: true })
+    .click()
+  await page.getByText('Max: 10,000').nth(0).click({ timeout: 60_000 })
+  await page.getByText('Estimated gas cost:$').waitFor({ timeout: 90_000 })
+  await gui.validateContractInteraction(
+    'div:has-text("Approve") >> button >> nth=1',
+    '0x8443364625e09a33d793acd03acc1f3b5dbfa6f6'
+  )
+  await gui.validateContractInteraction(
+    'button >> span:has-text("Wrap tokens") >> nth=0',
+    '0x8443364625e09a33d793acd03acc1f3b5dbfa6f6'
+  )
+  await page
+    .locator('reach-portal')
+    .filter({ hasText: 'Transactions signed!' })
+    .locator('button')
+    .click()
+})

--- a/tests/RTokens.gui.ts
+++ b/tests/RTokens.gui.ts
@@ -1,0 +1,65 @@
+import { test } from '@guardianui/test'
+import RTokens from './RTokens.json'
+import { setAllowanceAtSlot, setBalanceAtSlot } from './utils'
+
+for (const rtoken of Object.keys(RTokens)) {
+  test(`Mint RToken ${rtoken}`, async ({ page, gui }) => {
+    // Fork Mainnet
+    await gui.initializeChain(1, 17586536)
+
+    // Go to RToken mint page
+    await page.goto(`http://localhost:3000/#/issuance?token=${rtoken}`)
+
+    // Block unnecessary http requests to speed up the tests
+    await page.route('**/*.{png,jpg,jpeg,webp}', (route) => route.abort())
+    await page.route(/(analytics|font|thegraph)/, (route) => route.abort())
+
+    // Go to RToken mint page
+    await page.goto(`http://localhost:3000/#/issuance?token=${rtoken}`)
+    await gui.setEthBalance('100000000000000000000000')
+
+    const collaterals = RTokens[rtoken]
+    for (const collateral of collaterals) {
+      const address = collateral[0]
+      const balanceSlot = collateral[1]
+      const allowanceSlot = collateral[2]
+
+      await setBalanceAtSlot({
+        token: address,
+        slotNumber: `${balanceSlot}`,
+        value: '100000000000000000000000',
+        gui,
+      })
+
+      // NOTE:
+      // We need to bypass the allowance because we cannot approve
+      // the collateral token one by one via the UI. The guardiantest hangs when
+      // handling multiple transaction confirmations.
+      await setAllowanceAtSlot({
+        token: address,
+        spender: rtoken,
+        slotNumber: `${allowanceSlot}`,
+        value: '100000000000000000000000',
+        gui,
+      })
+    }
+    await page.reload()
+
+    await page.getByPlaceholder('Mint amount').type('1000')
+    await page
+      .getByText('Missing collateral')
+      .waitFor({ state: 'hidden', timeout: 60_000 })
+
+    await page.getByRole('button', { name: '+ Mint' }).click()
+    await page.getByText('Collateral distribution').click()
+    await gui.validateContractInteraction(
+      'button >> span:has-text("Begin minting") >> nth=0',
+      rtoken
+    )
+    await page
+      .locator('reach-portal')
+      .filter({ hasText: 'Transaction signed!' })
+      .locator('button')
+      .click()
+  })
+}

--- a/tests/getRTokens.ts
+++ b/tests/getRTokens.ts
@@ -1,0 +1,60 @@
+/**
+ * Given list of RTokens, fetch all collaterals from Facade contract then
+ * find the ERC20 mapping
+ */
+import { ethers } from 'ethers'
+import { Facade } from '../src/abis'
+import { ChainId } from '../src/utils/chains'
+import { FACADE_ADDRESS } from '../src/utils/addresses'
+import { createAnvil } from '@viem/anvil'
+import { config } from 'dotenv'
+import { findAllowanceSlot, findBalanceSlot } from './utils'
+
+config()
+
+const rtokens = [
+  '0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8', // ETH+
+  '0xA0d69E286B938e21CBf7E51D71F6A4c8918f482F', // eUSD
+  '0xaCdf0DBA4B9839b96221a8487e9ca660a48212be', // hyUSD
+]
+
+async function main() {
+  // Start anvil
+  const anvil = createAnvil({
+    forkUrl: `https://eth-mainnet.alchemyapi.io/v2/${process.env.GUARDIAN_UI_ALCHEMY_API_KEY}`,
+    forkBlockNumber: 17586536n,
+  })
+  await anvil.start()
+
+  const anvilProvider = new ethers.providers.JsonRpcProvider(
+    'http://localhost:8545'
+  )
+  const provider = new ethers.providers.JsonRpcProvider(
+    'https://cloudflare-eth.com'
+  )
+  const facadeContract = new ethers.Contract(
+    FACADE_ADDRESS[ChainId.Mainnet],
+    Facade,
+    provider
+  )
+  const data = {}
+  for (const rtoken of rtokens) {
+    const collaterals = await facadeContract.basketTokens(rtoken)
+    for (const collateral of collaterals) {
+      const balanceSlot = await findBalanceSlot(collateral, anvilProvider)
+      const allowanceSlot = await findAllowanceSlot(collateral, anvilProvider)
+      const rtokenData = data[rtoken]
+      if (rtokenData == null) {
+        data[rtoken] = [[collateral, balanceSlot, allowanceSlot]]
+      } else {
+        data[rtoken].push([collateral, balanceSlot, allowanceSlot])
+      }
+    }
+  }
+
+  console.log(JSON.stringify(data))
+
+  await anvil.stop()
+}
+
+main()

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,162 @@
+import { ethers } from 'ethers'
+
+export const getBalanceSlot = (userAddress: any, mappingSlot: any) => {
+  return ethers.utils.solidityKeccak256(
+    ['uint256', 'uint256'],
+    [userAddress, mappingSlot]
+  )
+}
+
+export async function setBalanceAtSlot(params: {
+  token: string
+  slotNumber: string
+  value: string
+  gui: any
+}) {
+  const { token, slotNumber, value, gui } = params
+  const userAddress = await gui.getWalletAddress()
+  const userBalanceSlot = getBalanceSlot(userAddress, slotNumber)
+  await gui.setContractStorageSlot(
+    token,
+    userBalanceSlot,
+    ethers.utils.hexZeroPad(
+      ethers.utils.hexlify(ethers.BigNumber.from(value)),
+      32
+    )
+  )
+  console.log(`Balance token ${token} = ${value}`)
+}
+
+export const getAllowanceSlot = (owner: any, spender: any, slotNumber: any) => {
+  const innerMappingSlot = ethers.utils.solidityKeccak256(
+    ['uint256', 'uint256'],
+    [owner, slotNumber]
+  )
+
+  return ethers.utils.solidityKeccak256(
+    ['uint256', 'uint256'],
+    [spender, innerMappingSlot]
+  )
+}
+
+export async function setAllowanceAtSlot(params: {
+  token: string
+  spender: string
+  value: string
+  slotNumber: string
+  gui: any
+}) {
+  const { token, spender, slotNumber, value, gui } = params
+  const owner = await gui.getWalletAddress()
+  const allowanceSlot = getAllowanceSlot(owner, spender, slotNumber)
+  await gui.setContractStorageSlot(
+    token,
+    allowanceSlot,
+    ethers.utils.hexZeroPad(
+      ethers.utils.hexlify(ethers.BigNumber.from(value)),
+      32
+    )
+  )
+  console.log(`Allowance token ${token} for ${spender} = ${value}`)
+}
+
+export const checkBalanceSlot = async (
+  erc20Address: any,
+  mappingSlot: any,
+  provider: any
+) => {
+  // Get the balance slot for a zero address user
+  const userAddress = ethers.constants.AddressZero
+  const balanceSlot = getBalanceSlot(userAddress, mappingSlot)
+
+  // Set the storage slot to a non-zero value
+  const value: any = 0xdeadbeef
+  const storageValue = ethers.utils.hexlify(ethers.utils.zeroPad(value, 32))
+  await provider.send('anvil_setStorageAt', [
+    erc20Address,
+    balanceSlot,
+    storageValue,
+  ])
+
+  // Check if the balance is equal to the value
+  const erc20Contract = new ethers.Contract(
+    erc20Address,
+    ['function balanceOf(address) view returns (uint)'],
+    provider
+  )
+  return (await erc20Contract.balanceOf(userAddress)) == value
+}
+
+export const findBalanceSlot = async (erc20Address: any, provider: any) => {
+  // Take a snapshot of the blockchain state to revert to later
+  const snapshot = await provider.send('evm_snapshot', [])
+
+  // Iterate over the storage slots to find the balance mapping
+  for (let slotNumber = 0; slotNumber < 100; slotNumber++) {
+    try {
+      if (await checkBalanceSlot(erc20Address, slotNumber, provider)) {
+        // Revert to the snapshot to reset the blockchain state
+        await provider.send('evm_revert', [snapshot])
+
+        // Return the slot number
+        return slotNumber
+      }
+    } catch {}
+
+    // Revert to the snapshot to reset the blockchain state
+    await provider.send('evm_revert', [snapshot])
+  }
+}
+
+export const checkAllowanceSlot = async (
+  erc20Address: any,
+  mappingSlot: any,
+  provider: any
+) => {
+  // Get the allowance slot for a zero address user and spender
+  const userAddress = ethers.constants.AddressZero
+  const spenderAddress = ethers.constants.AddressZero
+  const allowanceSlot = getAllowanceSlot(
+    userAddress,
+    spenderAddress,
+    mappingSlot
+  )
+
+  // Set the storage slot to a non-zero value
+  const value: any = 0x07bcc9f5
+  const storageValue = ethers.utils.hexlify(ethers.utils.zeroPad(value, 32))
+  await provider.send('anvil_setStorageAt', [
+    erc20Address,
+    allowanceSlot,
+    storageValue,
+  ])
+
+  // Check if the allowance is equal to the value
+  const erc20Contract = new ethers.Contract(
+    erc20Address,
+    ['function allowance(address,address) view returns (uint)'],
+    provider
+  )
+  return (await erc20Contract.allowance(userAddress, spenderAddress)) == value
+}
+
+export const findAllowanceSlot = async (erc20Address: any, provider: any) => {
+  // Take a snapshot of the blockchain state to revert to later
+  const snapshot = await provider.send('evm_snapshot', [])
+
+  // Iterate over the storage slots to find the allowance mapping
+  for (let slotNumber = 0; slotNumber < 100; slotNumber++) {
+    try {
+      if (await checkAllowanceSlot(erc20Address, slotNumber, provider)) {
+        // Revert to the snapshot to reset the blockchain state
+        await provider.send('evm_revert', [snapshot])
+
+        // Return the slot number
+        return slotNumber
+      }
+    } catch {}
+
+    // Revert to the snapshot to reset the blockchain state
+    await provider.send('evm_revert', [snapshot])
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "src",
     "target": "esnext",
-    "lib": ["dom", "dom.iterable",  "es2020", "esnext"],
+    "lib": ["dom", "dom.iterable", "es2020", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2097,6 +2097,190 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild-kit/cjs-loader@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "@esbuild-kit/cjs-loader@npm:2.4.2"
+  dependencies:
+    "@esbuild-kit/core-utils": ^3.0.0
+    get-tsconfig: ^4.4.0
+  checksum: e346e339bfc7eff5c52c270fd0ec06a7f2341b624adfb69f84b7d83f119c35070420906f2761a0b4604e0a0ec90e35eaf12544585476c428ed6d6ee3b250c0fe
+  languageName: node
+  linkType: hard
+
+"@esbuild-kit/core-utils@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "@esbuild-kit/core-utils@npm:3.1.0"
+  dependencies:
+    esbuild: ~0.17.6
+    source-map-support: ^0.5.21
+  checksum: d54fd5adb3ce6784d84bb025ad54ddcfbab99267071a7f65298e547f56696f0b9d0dba96c535f9678a30d4887ec71cd445fdd277d65fbec1f3b504f6808f693e
+  languageName: node
+  linkType: hard
+
+"@esbuild-kit/esm-loader@npm:^2.5.5":
+  version: 2.5.5
+  resolution: "@esbuild-kit/esm-loader@npm:2.5.5"
+  dependencies:
+    "@esbuild-kit/core-utils": ^3.0.0
+    get-tsconfig: ^4.4.0
+  checksum: 9d4a03ffc937fbec75a8456c3d45d7cdb1a65768416791a5720081753502bc9f485ba27942a46f564b12483b140a8a46c12433a4496430d93e4513e430484ec7
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/android-arm64@npm:0.17.19"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/android-arm@npm:0.17.19"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/android-x64@npm:0.17.19"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/darwin-arm64@npm:0.17.19"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/darwin-x64@npm:0.17.19"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/freebsd-arm64@npm:0.17.19"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/freebsd-x64@npm:0.17.19"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-arm64@npm:0.17.19"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-arm@npm:0.17.19"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-ia32@npm:0.17.19"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-loong64@npm:0.17.19"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-mips64el@npm:0.17.19"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-ppc64@npm:0.17.19"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-riscv64@npm:0.17.19"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-s390x@npm:0.17.19"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-x64@npm:0.17.19"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/netbsd-x64@npm:0.17.19"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/openbsd-x64@npm:0.17.19"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/sunos-x64@npm:0.17.19"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/win32-arm64@npm:0.17.19"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/win32-ia32@npm:0.17.19"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/win32-x64@npm:0.17.19"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.2.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
@@ -2547,6 +2731,17 @@ __metadata:
   peerDependencies:
     graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
   checksum: fa44443accd28c8cf4cb96aaaf39d144a22e8b091b13366843f4e97d19c7bfeaf609ce3c7603a4aeffe385081eaf8ea245d078633a7324c11c5ec4b2011bb76d
+  languageName: node
+  linkType: hard
+
+"@guardianui/test@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@guardianui/test@npm:1.0.4"
+  dependencies:
+    "@playwright/test": ~1.33.0
+    dotenv: ^16.0.3
+    ethers: 5.7.2
+  checksum: 4e6b3ff40c77c353c70348456686401290deec7f6557b716d24b26eb4d4b032b27b9da1583744d1f2050f9123fa1337590b0d54d3d0611b91a04544579042657
   languageName: node
   linkType: hard
 
@@ -3497,6 +3692,22 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 6ad6a00fc4f2f2cfc6bff76fb1d88b8ee20bc0601e18ebb01b6d4be583733a860239a521a7fbca73b612e66705078809483549d2b18f370eb346c5155c8e4a0f
+  languageName: node
+  linkType: hard
+
+"@playwright/test@npm:1.33.0, @playwright/test@npm:~1.33.0":
+  version: 1.33.0
+  resolution: "@playwright/test@npm:1.33.0"
+  dependencies:
+    "@types/node": "*"
+    fsevents: 2.3.2
+    playwright-core: 1.33.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: cec3215fc92c1cb9f5bfba357ea1cbe97b54979ab82f9d34a2287b1687cda5e0966b8ea7290dcd35416e18668e56d5781b6b8c4cec64baf12f3ae8dde0f68f5e
   languageName: node
   linkType: hard
 
@@ -5279,6 +5490,18 @@ __metadata:
     ethers: ^5.3.1
     tiny-invariant: ^1.3.1
   checksum: 524519c4f5492a721de9215f4c74c18af4a8a4f676273ccc9c01512fe36c8e8ac51dd3474b19021522b76ef2edd25d9c871b0eb051e22b6564e37cd2b9422920
+  languageName: node
+  linkType: hard
+
+"@viem/anvil@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "@viem/anvil@npm:0.0.6"
+  dependencies:
+    execa: ^7.1.1
+    get-port: ^6.1.2
+    http-proxy: ^1.18.1
+    ws: ^8.13.0
+  checksum: 7ef4481324c12c75b4587f3d98560b610a506b73b135f853bb6ea5db2893e3419f53df403fd8b1e9585732ed04515d5710b3fdae72ff8ece1425c59b74882e87
   languageName: node
   linkType: hard
 
@@ -8691,6 +8914,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.0.3, dotenv@npm:^16.3.1":
+  version: 16.3.1
+  resolution: "dotenv@npm:16.3.1"
+  checksum: 15d75e7279018f4bafd0ee9706593dd14455ddb71b3bcba9c52574460b7ccaf67d5cf8b2c08a5af1a9da6db36c956a04a1192b101ee102a3e0cf8817bbcf3dfd
+  languageName: node
+  linkType: hard
+
 "duplexer@npm:^0.1.2":
   version: 0.1.2
   resolution: "duplexer@npm:0.1.2"
@@ -9034,6 +9264,83 @@ __metadata:
     es6-iterator: ^2.0.3
     es6-symbol: ^3.1.1
   checksum: 19ca15f46d50948ce78c2da5f21fb5b1ef45addd4fe17b5df952ff1f2a3d6ce4781249bc73b90995257264be2a98b2ec749bb2aba0c14b5776a1154178f9c927
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:~0.17.6":
+  version: 0.17.19
+  resolution: "esbuild@npm:0.17.19"
+  dependencies:
+    "@esbuild/android-arm": 0.17.19
+    "@esbuild/android-arm64": 0.17.19
+    "@esbuild/android-x64": 0.17.19
+    "@esbuild/darwin-arm64": 0.17.19
+    "@esbuild/darwin-x64": 0.17.19
+    "@esbuild/freebsd-arm64": 0.17.19
+    "@esbuild/freebsd-x64": 0.17.19
+    "@esbuild/linux-arm": 0.17.19
+    "@esbuild/linux-arm64": 0.17.19
+    "@esbuild/linux-ia32": 0.17.19
+    "@esbuild/linux-loong64": 0.17.19
+    "@esbuild/linux-mips64el": 0.17.19
+    "@esbuild/linux-ppc64": 0.17.19
+    "@esbuild/linux-riscv64": 0.17.19
+    "@esbuild/linux-s390x": 0.17.19
+    "@esbuild/linux-x64": 0.17.19
+    "@esbuild/netbsd-x64": 0.17.19
+    "@esbuild/openbsd-x64": 0.17.19
+    "@esbuild/sunos-x64": 0.17.19
+    "@esbuild/win32-arm64": 0.17.19
+    "@esbuild/win32-ia32": 0.17.19
+    "@esbuild/win32-x64": 0.17.19
+  dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: ac11b1a5a6008e4e37ccffbd6c2c054746fc58d0ed4a2f9ee643bd030cfcea9a33a235087bc777def8420f2eaafb3486e76adb7bdb7241a9143b43a69a10afd8
   languageName: node
   linkType: hard
 
@@ -9511,7 +9818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^5.3.1, ethers@npm:^5.4.6, ethers@npm:^5.7.2":
+"ethers@npm:5.7.2, ethers@npm:^5.3.1, ethers@npm:^5.4.6, ethers@npm:^5.7.2":
   version: 5.7.2
   resolution: "ethers@npm:5.7.2"
   dependencies:
@@ -9594,6 +9901,23 @@ __metadata:
     signal-exit: ^3.0.3
     strip-final-newline: ^2.0.0
   checksum: fba9022c8c8c15ed862847e94c252b3d946036d7547af310e344a527e59021fd8b6bb0723883ea87044dc4f0201f949046993124a42ccb0855cae5bf8c786343
+  languageName: node
+  linkType: hard
+
+"execa@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "execa@npm:7.1.1"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^6.0.1
+    human-signals: ^4.3.0
+    is-stream: ^3.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^5.1.0
+    onetime: ^6.0.0
+    signal-exit: ^3.0.7
+    strip-final-newline: ^3.0.0
+  checksum: 21fa46fc69314ace4068cf820142bdde5b643a5d89831c2c9349479c1555bff137a291b8e749e7efca36535e4e0a8c772c11008ca2e84d2cbd6ca141a3c8f937
   languageName: node
   linkType: hard
 
@@ -10152,7 +10476,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:~2.3.1, fsevents@npm:~2.3.2":
+"fsevents@npm:2.3.2, fsevents@npm:^2.3.2, fsevents@npm:~2.3.1, fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -10162,7 +10486,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
   dependencies:
@@ -10283,7 +10607,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.0":
+"get-port@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "get-port@npm:6.1.2"
+  checksum: e3c3d591492a11393455ef220f24c812a28f7da56ec3e4a2512d931a1f196d42850b50ac6138349a44622eda6dc3c0ccd8495cd91376d968e2d9e6f6f849e0a9
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
@@ -10297,6 +10628,15 @@ __metadata:
     call-bind: ^1.0.2
     get-intrinsic: ^1.1.1
   checksum: 9ceff8fe968f9270a37a1f73bf3f1f7bda69ca80f4f80850670e0e7b9444ff99323f7ac52f96567f8b5f5fbe7ac717a0d81d3407c7313e82810c6199446a5247
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.4.0":
+  version: 4.6.2
+  resolution: "get-tsconfig@npm:4.6.2"
+  dependencies:
+    resolve-pkg-maps: ^1.0.0
+  checksum: e791e671a9b55e91efea3ca819ecd7a25beae679e31c83234bf3dd62ddd93df070c1b95ae7e29d206358ebb6408f6f79ac6d83a32a3bbd6a6d217babe23de077
   languageName: node
   linkType: hard
 
@@ -11025,6 +11365,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"human-signals@npm:^4.3.0":
+  version: 4.3.1
+  resolution: "human-signals@npm:4.3.1"
+  checksum: 6f12958df3f21b6fdaf02d90896c271df00636a31e2bbea05bddf817a35c66b38a6fdac5863e2df85bd52f34958997f1f50350ff97249e1dff8452865d5235d1
+  languageName: node
+  linkType: hard
+
 "humanize-duration@npm:^3.28.0":
   version: 3.28.0
   resolution: "humanize-duration@npm:3.28.0"
@@ -11632,6 +11979,13 @@ __metadata:
   version: 2.0.1
   resolution: "is-stream@npm:2.0.1"
   checksum: b8e05ccdf96ac330ea83c12450304d4a591f9958c11fd17bed240af8d5ffe08aedafa4c0f4cfccd4d28dc9d4d129daca1023633d5c11601a6cbc77521f6fae66
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-stream@npm:3.0.0"
+  checksum: 172093fe99119ffd07611ab6d1bcccfe8bc4aa80d864b15f43e63e54b7abc71e779acd69afdb854c4e2a67fdc16ae710e370eda40088d1cfc956a50ed82d8f16
   languageName: node
   linkType: hard
 
@@ -13988,6 +14342,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-fn@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mimic-fn@npm:4.0.0"
+  checksum: 995dcece15ee29aa16e188de6633d43a3db4611bcf93620e7e62109ec41c79c0f34277165b8ce5e361205049766e371851264c21ac64ca35499acb5421c2ba56
+  languageName: node
+  linkType: hard
+
 "min-indent@npm:^1.0.0":
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
@@ -14561,6 +14922,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "npm-run-path@npm:5.1.0"
+  dependencies:
+    path-key: ^4.0.0
+  checksum: dc184eb5ec239d6a2b990b43236845332ef12f4e0beaa9701de724aa797fe40b6bbd0157fb7639d24d3ab13f5d5cf22d223a19c6300846b8126f335f788bee66
+  languageName: node
+  linkType: hard
+
 "npm-user-validate@npm:^2.0.0":
   version: 2.0.0
   resolution: "npm-user-validate@npm:2.0.0"
@@ -14845,6 +15215,15 @@ __metadata:
   dependencies:
     mimic-fn: ^2.1.0
   checksum: 2478859ef817fc5d4e9c2f9e5728512ddd1dbc9fb7829ad263765bb6d3b91ce699d6e2332eef6b7dff183c2f490bd3349f1666427eaba4469fba0ac38dfd0d34
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "onetime@npm:6.0.0"
+  dependencies:
+    mimic-fn: ^4.0.0
+  checksum: 0846ce78e440841335d4e9182ef69d5762e9f38aa7499b19f42ea1c4cd40f0b4446094c455c713f9adac3f4ae86f613bb5e30c99e52652764d06a89f709b3788
   languageName: node
   linkType: hard
 
@@ -15154,6 +15533,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-key@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-key@npm:4.0.0"
+  checksum: 8e6c314ae6d16b83e93032c61020129f6f4484590a777eed709c4a01b50e498822b00f76ceaf94bc64dbd90b327df56ceadce27da3d83393790f1219e07721d7
+  languageName: node
+  linkType: hard
+
 "path-parse@npm:^1.0.7":
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
@@ -15294,6 +15680,15 @@ __metadata:
   dependencies:
     find-up: ^3.0.0
   checksum: 5bac346b7c7c903613c057ae3ab722f320716199d753f4a7d053d38f2b5955460f3e6ab73b4762c62fd3e947f58e04f1343e92089e7bb6091c90877406fcd8c8
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.33.0":
+  version: 1.33.0
+  resolution: "playwright-core@npm:1.33.0"
+  bin:
+    playwright: cli.js
+  checksum: 5fb7bda06a8b73b56b85b5a0b8f711211dde57a375d9379289e22239b2de879c6d93c8fdc9ba44b932bf100914ab1ca1a55697ad88440fdd0a39101fc020b77f
   languageName: node
   linkType: hard
 
@@ -17246,12 +17641,14 @@ __metadata:
     "@dnd-kit/utilities": ^3.2.0
     "@emotion/react": ^11.9.0
     "@emotion/styled": ^11.8.1
+    "@guardianui/test": ^1.0.4
     "@lc-labs/rtokens": 1.0.9
     "@lingui/cli": ^3.13.3
     "@lingui/core": ^3.13.3
     "@lingui/macro": ^3.13.3
     "@lingui/react": ^3.13.3
     "@metamask/contract-metadata": 2.3.1
+    "@playwright/test": 1.33.0
     "@popperjs/core": ^2.11.5
     "@reach/dialog": ^0.17.0
     "@reach/portal": ^0.17.0
@@ -17271,6 +17668,7 @@ __metadata:
     "@types/uuid": ^8.3.4
     "@uiw/react-md-editor": ^3.20.5
     "@uniswap/permit2-sdk": ^1.2.0
+    "@viem/anvil": ^0.0.6
     "@walletconnect/ethereum-provider": 2.8.6
     "@web3-react/coinbase-wallet": 8.2.0
     "@web3-react/core": 8.2.0
@@ -17283,6 +17681,7 @@ __metadata:
     babel-preset-react-app: ^10.0.1
     buffer: ^6.0.3
     dayjs: ^1.11.3
+    dotenv: ^16.3.1
     ethers: ^5.7.2
     fast-deep-equal: ^3.1.3
     fast-memoize: ^2.5.2
@@ -17313,6 +17712,7 @@ __metadata:
     source-map-explorer: ^2.5.2
     swr: ^1.2.2
     theme-ui: ^0.15.4
+    tsx: ^3.12.7
     typechain: ^8.1.0
     typescript: ^4.6.2
     util: ^0.12.4
@@ -17557,6 +17957,13 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 4ceeb9113e1b1372d0cd969f3468fa042daa1dd9527b1b6bb88acb6ab55d8b9cd65dbf18819f9f9ddf0db804990901dcdaade80a215e7b2c23daae38e64f5bdf
+  languageName: node
+  linkType: hard
+
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 1012afc566b3fdb190a6309cc37ef3b2dcc35dff5fa6683a9d00cd25c3247edfbc4691b91078c97adc82a29b77a2660c30d791d65dab4fc78bfc473f60289977
   languageName: node
   linkType: hard
 
@@ -18283,7 +18690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.6, source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.21, source-map-support@npm:^0.5.6, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -18685,6 +19092,13 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
+  languageName: node
+  linkType: hard
+
+"strip-final-newline@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-final-newline@npm:3.0.0"
+  checksum: 23ee263adfa2070cd0f23d1ac14e2ed2f000c9b44229aec9c799f1367ec001478469560abefd00c5c99ee6f0b31c137d53ec6029c53e9f32a93804e18c201050
   languageName: node
   linkType: hard
 
@@ -19345,6 +19759,23 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^3.12.7":
+  version: 3.12.7
+  resolution: "tsx@npm:3.12.7"
+  dependencies:
+    "@esbuild-kit/cjs-loader": ^2.4.2
+    "@esbuild-kit/core-utils": ^3.0.0
+    "@esbuild-kit/esm-loader": ^2.5.5
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.js
+  checksum: ddec149ad263e5c75fc8fde5c6ba7ec2ee390934c0a2e2c23897bacab83bc8c665955a23b608a19c42f49c14a7362cf74ad793b52cc94eda684be5c2c13fdb4d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

[Register.app](http://register.app/) is the user-interface for the Reserve Protocol. It was built to allow users to deploy, view, use, and govern RTokens, and is currently doing its job well. There are currently no tests in the Register codebase. 

The goal of this badge is to setup an E2E testing framework that can be run locally and in github actions CI. [GuardianUI](https://www.guardianui.com/) should be used as the testing framework. 

## Deliverables

- [x] Setup an E2E testing framework in the Register repo, complete with a yarn command to run the tests locally. 
- [x] Setup a github action that runs the E2E tests in CI. 
- [x] Write an E2E test that forks from a recent mainnet block (hardcode this block in the repo) and issues 10,000 eUSD RTokens. The test can mock user balances of USDC, USDT, cUSDC, cUSDT, but it should wrap USDC & USDT into saUSDC & saUSDT via the UI, approve all 4 tokens via the UI, and issue eUSD via the UI. 
- [x] Write an E2E test that does something similar for ETH+ (can mock balances of both rETH and wstETH collateral tokens). 
- [x] Write an E2E test that does something similar for hyUSD (can mock balances of all 4 collateral tokens). 
- [x] Updated [README.md](http://readme.md/) with instructions on how to run the E2E tests locally.

## Notes

- I found some minor bugs in the approvals. `contract.estimateGas[tx.call.method]()` doesn't work with other rpc such as anvil or alchemy, but i've replaced with `contract.signer.estimateGas` to work for all rpcs