### PR TITLE
fix: override default Graph results limit

### DIFF
--- a/src/views/overview/components/PriceChart.tsx
+++ b/src/views/overview/components/PriceChart.tsx
@@ -26,7 +26,10 @@ const hourlyPriceQuery = gql`
 const dailyPriceQuery = gql`
   query getTokenDailyPrice($id: String!, $fromTime: Int!) {
     token(id: $id) {
-      snapshots: dailyTokenSnapshot(where: { timestamp_gte: $fromTime }) {
+      snapshots: dailyTokenSnapshot(
+        first: 1000
+        where: { timestamp_gte: $fromTime }
+      ) {
         timestamp
         priceUSD
       }

--- a/src/views/overview/components/StakingChart.tsx
+++ b/src/views/overview/components/StakingChart.tsx
@@ -27,7 +27,10 @@ const hourlyPriceQuery = gql`
 const dailyPriceQuery = gql`
   query getTokenDailyPrice($id: String!, $fromTime: Int!) {
     rtoken(id: $id) {
-      snapshots: dailySnapshots(where: { timestamp_gte: $fromTime }) {
+      snapshots: dailySnapshots(
+        first: 1000
+        where: { timestamp_gte: $fromTime }
+      ) {
         timestamp
         rsrStaked
       }

--- a/src/views/overview/components/SupplyChart.tsx
+++ b/src/views/overview/components/SupplyChart.tsx
@@ -27,7 +27,10 @@ const hourlyPriceQuery = gql`
 const dailyPriceQuery = gql`
   query getTokenDailyPrice($id: String!, $fromTime: Int!) {
     token(id: $id) {
-      snapshots: dailyTokenSnapshot(where: { timestamp_gte: $fromTime }) {
+      snapshots: dailyTokenSnapshot(
+        first: 1000
+        where: { timestamp_gte: $fromTime }
+      ) {
         timestamp
         supply: dailyTotalSupply
       }

--- a/src/views/staking/components/overview/ExchangeRate.tsx
+++ b/src/views/staking/components/overview/ExchangeRate.tsx
@@ -15,7 +15,10 @@ import { TIME_RANGES } from 'utils/constants'
 const query = gql`
   query getRTokenExchangeRate($id: String!, $fromTime: Int!) {
     rtoken(id: $id) {
-      snapshots: dailySnapshots(where: { timestamp_gte: $fromTime }) {
+      snapshots: dailySnapshots(
+        first: 1000
+        where: { timestamp_gte: $fromTime }
+      ) {
         timestamp
         rsrExchangeRate
       }


### PR DESCRIPTION
Previously, charts on the 1yr timescale would display truncated results because TheGraph fetches a max of 100 results by default. Now, we fetch the first 1000 to overcome this. 

<img width="448" alt="image" src="https://github.com/lc-labs/register/assets/71284258/a0e0255b-fa17-4985-9885-d5bc1bfea5d8">

Affects the follow charts: 
- RSR price 
- RToken price
- RToken supply
- RSR staked