### PR TITLE
Fix/improve zapper ux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@popperjs/core": "^2.11.5",
         "@rainbow-me/rainbowkit": "1.0.11",
         "@react-spring/web": "^9.7.1",
-        "@reserve-protocol/token-zapper": "2.5.2",
+        "@reserve-protocol/token-zapper": "2.5.3",
         "@uiw/react-md-editor": "^3.20.5",
         "@uniswap/permit2-sdk": "^1.2.0",
         "@viem/anvil": "^0.0.6",
@@ -4320,9 +4320,9 @@
       }
     },
     "node_modules/@reserve-protocol/token-zapper": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-2.5.2.tgz",
-      "integrity": "sha512-14kIQuwADJWWZPjg9YYN88ffPv9jafwiHS+saBSOeNwt3dbvB/2bYWjn0FErkAdMvbIYkQBHxiFS9Z6kXYFOpA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-2.5.3.tgz",
+      "integrity": "sha512-O6Ptv/rC6N43af20z/nvvTWqsml4yrZJjoG4vvAa1MxITZx21bImMlVeOIKJOyM11qLpiPF6R5ovavZu7n2H2w==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@popperjs/core": "^2.11.5",
     "@rainbow-me/rainbowkit": "1.0.11",
     "@react-spring/web": "^9.7.1",
-    "@reserve-protocol/token-zapper": "2.5.2",
+    "@reserve-protocol/token-zapper": "2.5.3",
     "@uiw/react-md-editor": "^3.20.5",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@viem/anvil": "^0.0.6",

--- a/src/views/issuance/components/zap/components/ZapButton.tsx
+++ b/src/views/issuance/components/zap/components/ZapButton.tsx
@@ -1,8 +1,22 @@
 import { LoadingButton, LoadingButtonProps } from 'components/button'
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { ui } from '../state/ui-atoms'
+import { previousZapTransaction, zapTransaction } from '../state/atoms'
+import { useEffect } from 'react'
 
 const ZapButton = (props: Partial<LoadingButtonProps>) => {
+  const tx = useAtomValue(zapTransaction)
+  const [, setPrevious] = useAtom(previousZapTransaction)
+  const ttx = tx.state === "hasData" ? tx.data : null
+  useEffect(() => {
+    
+    if (ttx != null) {
+      console.log("Setting previous")
+      setPrevious(ttx)
+    }
+    
+  }, [ttx])
+
   const [{ loading, enabled, label, loadingLabel }, onClick] = useAtom(
     ui.button
   )

--- a/src/views/issuance/components/zap/components/ZapInput.tsx
+++ b/src/views/issuance/components/zap/components/ZapInput.tsx
@@ -7,11 +7,16 @@ import { rTokenStateAtom } from 'state/atoms'
 import { Box, Checkbox, Flex, Text } from 'theme-ui'
 import {
   collectDust,
+  previousZapTransaction,
   selectedZapTokenAtom,
   zapInputString,
 } from '../state/atoms'
 import { ui, zapDust, zapDustValue } from '../state/ui-atoms'
-import { formatQty, FOUR_DIGITS, TWO_DIGITS } from '../state/formatTokenQuantity'
+import {
+  formatQty,
+  FOUR_DIGITS,
+  TWO_DIGITS,
+} from '../state/formatTokenQuantity'
 import { zapperLoaded } from '../state/zapper'
 import { Suspense } from 'react'
 
@@ -23,7 +28,7 @@ const ZapDust = () => {
     return null
   }
   const total = dustValue.total
-  
+
   let str = '+ ' + formatQty(total, TWO_DIGITS) + ' in dust'
   if (total.amount < 10000n) {
     str = '*'
@@ -36,9 +41,7 @@ const ZapDust = () => {
     <span
       title={
         'Dust generated:\n' +
-        dust
-          .map((i) => formatQty(i, FOUR_DIGITS))
-          .join('\n') +
+        dust.map((i) => formatQty(i, FOUR_DIGITS)).join('\n') +
         (zapCollectDust
           ? '\n\nDust will be returned to your wallet'
           : '\n\nDust will not be returned to your wallet')
@@ -98,10 +101,12 @@ const ZapOutputLabel = () => {
 }
 const ZapCollectDust = () => {
   const [checked, setChecked] = useAtom(collectDust)
+  const [, setPrevious] = useAtom(previousZapTransaction)
   return (
     <Flex
       onClick={() => {
         setChecked(!checked)
+        setPrevious(null)
       }}
       ml={3}
       mt={2}

--- a/src/views/issuance/components/zap/index.tsx
+++ b/src/views/issuance/components/zap/index.tsx
@@ -9,7 +9,6 @@ import ZapButton from './components/ZapButton'
 import ZapInput from './components/ZapInput'
 import { selectedZapTokenAtom } from './state/atoms'
 import { resolvedZapState } from './state/zapper'
-import { useWalletClient } from 'wagmi'
 
 const UpdateBlockAndGas = () => {
   const zapState = useAtomValue(resolvedZapState)
@@ -28,7 +27,6 @@ const UpdateBlockAndGas = () => {
  * Zap widget
  */
 const Zap = () => {
-  const enableZapper = useWalletClient().data?.account != null
   const [isZapping, setZapping] = useState(false)
   const rToken = useRToken()
   const selectedToken = useAtomValue(selectedZapTokenAtom)

--- a/src/views/issuance/components/zap/state/atoms.ts
+++ b/src/views/issuance/components/zap/state/atoms.ts
@@ -56,6 +56,7 @@ export const tokenToZapPopupState = atom(false)
 export const collectDust = atom(true)
 export const zapInputString = atomWithOnWrite('', (_, set, __) => {
   set(permitSignature, null)
+  set(previousZapTransaction, null)
 })
 export const tokenToZapUserSelected = atomWithOnWrite(
   null as Token | null,

--- a/src/views/issuance/components/zap/state/atoms.ts
+++ b/src/views/issuance/components/zap/state/atoms.ts
@@ -26,6 +26,8 @@ import {
 } from 'utils/atoms/utils'
 
 import { resolvedZapState, zappableTokens } from './zapper'
+import { type SearcherResult } from '@reserve-protocol/token-zapper/types/searcher/SearcherResult'
+import { type ZapTransaction } from '@reserve-protocol/token-zapper/types/searcher/ZapTransaction'
 
 /**
  * I've tried to keep react effects to a minimum so most async code is triggered via some signal
@@ -41,6 +43,14 @@ import { resolvedZapState, zappableTokens } from './zapper'
  * view/controller.
  */
 
+export const previousZapTransaction = atom<{
+  result: SearcherResult,
+  transaction: ZapTransaction,
+  permit2?: {
+    permit: PermitTransferFrom,
+    signature: string
+  }
+} | null>(null)
 // The only actual state the user controls:
 export const tokenToZapPopupState = atom(false)
 export const collectDust = atom(true)
@@ -53,6 +63,7 @@ export const tokenToZapUserSelected = atomWithOnWrite(
     if (prev !== next) {
       set(zapInputString, '')
       set(tokenToZapPopupState, false)
+      set(previousZapTransaction, null)
     }
   }
 )


### PR DESCRIPTION
Change:

Zapper UI: will not go into loading state when requoting because of updated block. This should resolve the issues where users don't get to use their zap because of requoting

Zapper internals:
Internal router CToken mint slippage will be based on the size of the minted amount rather than a static value. This should make zap transactions more likely to commit on chain.