### PR TITLE
update zapper to better handle on-chain rates appreciating over time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@popperjs/core": "^2.11.5",
         "@rainbow-me/rainbowkit": "1.0.11",
         "@react-spring/web": "^9.7.1",
-        "@reserve-protocol/token-zapper": "2.5.6",
+        "@reserve-protocol/token-zapper": "2.5.7",
         "@uiw/react-md-editor": "^3.20.5",
         "@uniswap/permit2-sdk": "^1.2.0",
         "@viem/anvil": "^0.0.6",
@@ -4320,9 +4320,9 @@
       }
     },
     "node_modules/@reserve-protocol/token-zapper": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-2.5.6.tgz",
-      "integrity": "sha512-XyflMrJJi37u+Pun3zy6q3XTpXoJy0q0802erP6CMy0DHRzWTa1otohut8D7iobPiRh6AZ716rOBPHQnJY6/Ig==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-2.5.7.tgz",
+      "integrity": "sha512-4lYXv1vd0HUQriXy7W+ooNhJU1HrmNUe9kQuXrTo0dlRUrC5mgmBPKE1Ro7ytZMG6X94NOSVDPa4z2QqOqV1ew==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@popperjs/core": "^2.11.5",
         "@rainbow-me/rainbowkit": "1.0.11",
         "@react-spring/web": "^9.7.1",
-        "@reserve-protocol/token-zapper": "2.5.7",
+        "@reserve-protocol/token-zapper": "2.6.0",
         "@uiw/react-md-editor": "^3.20.5",
         "@uniswap/permit2-sdk": "^1.2.0",
         "@viem/anvil": "^0.0.6",
@@ -4320,9 +4320,9 @@
       }
     },
     "node_modules/@reserve-protocol/token-zapper": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-2.5.7.tgz",
-      "integrity": "sha512-4lYXv1vd0HUQriXy7W+ooNhJU1HrmNUe9kQuXrTo0dlRUrC5mgmBPKE1Ro7ytZMG6X94NOSVDPa4z2QqOqV1ew==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-2.6.0.tgz",
+      "integrity": "sha512-nC1WopGs4fGBBqYVIkNg0k50m36gHjoCa13WivFqNbkphK+8fPs8Dr5ZBmEgCGH6ZSZiaeZgB0ag1gG8V7XgpQ==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@popperjs/core": "^2.11.5",
     "@rainbow-me/rainbowkit": "1.0.11",
     "@react-spring/web": "^9.7.1",
-    "@reserve-protocol/token-zapper": "2.5.7",
+    "@reserve-protocol/token-zapper": "2.6.0",
     "@uiw/react-md-editor": "^3.20.5",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@viem/anvil": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@popperjs/core": "^2.11.5",
     "@rainbow-me/rainbowkit": "1.0.11",
     "@react-spring/web": "^9.7.1",
-    "@reserve-protocol/token-zapper": "2.5.6",
+    "@reserve-protocol/token-zapper": "2.5.7",
     "@uiw/react-md-editor": "^3.20.5",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@viem/anvil": "^0.0.6",


### PR DESCRIPTION
A lot of reverts are happening because rates might change from the time a user submits a zap to when it actually gets committed on chain. I made the internal quoting in the zapper a bit more pessimistic, which should allow zap transactions to stay valid for up to 20 minutes even if the rate spikes to 10%+.  