### PR TITLE
Display Collateral Address

### DIFF
--- a/src/components/rtoken-setup/basket/UnitBasket.tsx
+++ b/src/components/rtoken-setup/basket/UnitBasket.tsx
@@ -111,6 +111,7 @@ const UnitBasket = ({ data, readOnly, unit, ...props }: UnitBasketProps) => {
           <IconInfo
             icon={<TokenLogo width={18} symbol={collateral.symbol} />}
             title={unit}
+            help={`Collateral Address: ${collateral.address}`}
             text={
               readOnly
                 ? collateral.symbol


### PR DESCRIPTION
Shows the actual collateral address when changing basket. Useful for when you're changing the collateral address with the same token symbols.