### PR TITLE
Unregister unused assets

### DIFF
--- a/src/components/rtoken-setup/atoms.ts
+++ b/src/components/rtoken-setup/atoms.ts
@@ -151,7 +151,6 @@ export const rtokenAllActiveCollateralsAtom = atom((get) => {
   const basketCollaterals = [
     ...primaryBasketCollaterals,
     ...backupBasketCollaterals,
-    ...['0x890FAa00C16EAD6AA76F18A1A7fe9C40838F9122'],
   ]
 
   const systemAssets: string[] = []

--- a/src/components/rtoken-setup/atoms.ts
+++ b/src/components/rtoken-setup/atoms.ts
@@ -1,9 +1,17 @@
 import { t } from '@lingui/macro'
-import { atom } from 'jotai'
+import { atom, useAtomValue } from 'jotai'
 import { atomWithReset } from 'jotai/utils'
-import { secondsPerBlockAtom } from 'state/atoms'
+import {
+  chainIdAtom,
+  rTokenAssetsAtom,
+  rTokenAtom,
+  secondsPerBlockAtom,
+  selectedRTokenAtom,
+} from 'state/atoms'
 import { CollateralPlugin } from 'types'
 import { isAddress, truncateDecimals } from 'utils'
+import { RSR_ADDRESS } from 'utils/addresses'
+import collateralPlugins from 'utils/plugins'
 import { Address } from 'viem'
 
 export interface Collateral {
@@ -72,7 +80,6 @@ export const getCollateralFromBasket = (basket: Basket | BackupBasket) => {
     [] as string[]
   )
 }
-
 // TODO: This may not be needed?
 const getCollateralByTarget = (collaterals: CollateralPlugin[]) => {
   return collaterals.reduce((acc, collateral) => {
@@ -131,6 +138,41 @@ export const primaryBasketCollateralAtom = atom((get) => {
 
 export const backupBasketCollateralAtom = atom((get) => {
   return getCollateralFromBasket(get(backupCollateralAtom))
+})
+
+export const rtokenAllActiveCollateralsAtom = atom((get) => {
+  const primaryBasketCollaterals = get(primaryBasketCollateralAtom)
+  const backupBasketCollaterals = get(backupBasketCollateralAtom)
+  const rToken = get(selectedRTokenAtom)
+  const allAssets = get(rTokenAssetsAtom)
+
+  const plugins = collateralPlugins[get(chainIdAtom)]
+
+  const basketCollaterals = [
+    ...primaryBasketCollaterals,
+    ...backupBasketCollaterals,
+    ...['0x890FAa00C16EAD6AA76F18A1A7fe9C40838F9122'],
+  ]
+
+  const systemAssets: string[] = []
+  Object.entries(allAssets || {}).forEach(([erc20, asset]) => {
+    if (
+      erc20.toLowerCase() === RSR_ADDRESS[get(chainIdAtom)].toLowerCase() ||
+      erc20.toLowerCase() === rToken?.toLowerCase()
+    )
+      systemAssets.push(asset.address)
+  })
+  const rewardTokenCollaterals = basketCollaterals.reduce(
+    (acc, collAddr: string) => [
+      ...acc,
+      ...(plugins.find(
+        (p) => p.address.toLowerCase() === collAddr.toLowerCase()
+      )?.rewardTokens || []),
+    ],
+    [] as string[]
+  )
+
+  return [...basketCollaterals, ...rewardTokenCollaterals, ...systemAssets]
 })
 
 export const addBackupCollateralAtom = atom(

--- a/src/components/rtoken-setup/token/RevenueSplit.tsx
+++ b/src/components/rtoken-setup/token/RevenueSplit.tsx
@@ -9,15 +9,12 @@ import { useForm } from 'react-hook-form'
 import DocsLink from 'components/docs-link/DocsLink'
 import { Box, BoxProps, Card, Divider, Flex, Text, Link } from 'theme-ui'
 import {
-  basketAtom,
   ExternalAddressSplit,
   isRevenueValidAtom,
   isValidExternalMapAtom,
   revenueSplitAtom,
-  rtokenAllActiveCollateralsAtom,
 } from '../atoms'
 import ExternalRevenueSpit from './ExternalRevenueSplit'
-import { rTokenAssetsAtom } from 'state/atoms'
 
 const updateExternalShareAtom = atom(
   null,
@@ -46,15 +43,7 @@ const RevenueSplit = (props: BoxProps) => {
   const updateExternalShare = useSetAtom(updateExternalShareAtom)
   const isValid = useAtomValue(isRevenueValidAtom)
   const isValidExternals = useAtomValue(isValidExternalMapAtom)
-  const registeredErc20s = useAtomValue(rTokenAssetsAtom)
-  const registeredAssets = Object.values(registeredErc20s || {}).map(
-    (asset) => asset.address
-  )
-  const usedAssets = useAtomValue(rtokenAllActiveCollateralsAtom)
 
-  const difference = registeredAssets.filter((x) => !usedAssets.includes(x))
-
-  console.log({ usedAssets, registeredAssets, difference })
   const {
     register,
     watch,

--- a/src/components/rtoken-setup/token/RevenueSplit.tsx
+++ b/src/components/rtoken-setup/token/RevenueSplit.tsx
@@ -9,12 +9,15 @@ import { useForm } from 'react-hook-form'
 import DocsLink from 'components/docs-link/DocsLink'
 import { Box, BoxProps, Card, Divider, Flex, Text, Link } from 'theme-ui'
 import {
+  basketAtom,
   ExternalAddressSplit,
   isRevenueValidAtom,
   isValidExternalMapAtom,
   revenueSplitAtom,
+  rtokenAllActiveCollateralsAtom,
 } from '../atoms'
 import ExternalRevenueSpit from './ExternalRevenueSplit'
+import { rTokenAssetsAtom } from 'state/atoms'
 
 const updateExternalShareAtom = atom(
   null,
@@ -43,6 +46,15 @@ const RevenueSplit = (props: BoxProps) => {
   const updateExternalShare = useSetAtom(updateExternalShareAtom)
   const isValid = useAtomValue(isRevenueValidAtom)
   const isValidExternals = useAtomValue(isValidExternalMapAtom)
+  const registeredErc20s = useAtomValue(rTokenAssetsAtom)
+  const registeredAssets = Object.values(registeredErc20s || {}).map(
+    (asset) => asset.address
+  )
+  const usedAssets = useAtomValue(rtokenAllActiveCollateralsAtom)
+
+  const difference = registeredAssets.filter((x) => !usedAssets.includes(x))
+
+  console.log({ usedAssets, registeredAssets, difference })
   const {
     register,
     watch,

--- a/src/state/rtoken/atoms/rTokenBackupAtom.ts
+++ b/src/state/rtoken/atoms/rTokenBackupAtom.ts
@@ -1,7 +1,7 @@
 import ERC20 from 'abis/ERC20'
 import FacadeRead from 'abis/FacadeRead'
 import { BackupBasket } from 'components/rtoken-setup/atoms'
-import { chainIdAtom } from 'state/atoms'
+import { chainIdAtom, rTokenAssetsAtom } from 'state/atoms'
 import { FACADE_ADDRESS } from 'utils/addresses'
 import { atomWithLoadable } from 'utils/atoms/utils'
 import { stringToHex } from 'viem'
@@ -12,10 +12,11 @@ import rTokenBasketAtom from './rTokenBasketAtom'
 const rTokenBackupAtom = atomWithLoadable(async (get) => {
   const rToken = get(rTokenAtom)
   const rTokenBasket = get(rTokenBasketAtom)
+  const assets = get(rTokenAssetsAtom)
   const targetUnits = Object.keys(rTokenBasket)
   const chainId = get(chainIdAtom)
 
-  if (!rToken?.main || !rTokenBasketAtom) {
+  if (!rToken?.main || !rTokenBasketAtom || !assets) {
     return null
   }
 
@@ -62,7 +63,7 @@ const rTokenBackupAtom = atomWithLoadable(async (get) => {
     backupBasket[targetUnits[index]] = {
       diversityFactor: Number(max),
       collaterals: erc20s.map((address, i) => ({
-        address,
+        address: assets[address].address,
         targetName: targetUnits[index],
         symbol: symbols[i],
         erc20: address,

--- a/src/views/governance/views/proposal/atoms.ts
+++ b/src/views/governance/views/proposal/atoms.ts
@@ -14,6 +14,7 @@ import Broker from 'abis/Broker'
 import Main from 'abis/Main'
 import BrokerLegacy from 'abis/BrokerLegacy'
 import BasketHandler from 'abis/BasketHandler'
+import { RegisterAsset } from './hooks/useRegisterAssets'
 
 export const proposalTxIdAtom = atom('')
 
@@ -39,7 +40,9 @@ export const parametersChangesAtom = atomWithReset<ParameterChange[]>([])
 export const roleChangesAtom = atomWithReset<RoleChange[]>([])
 
 export const unregisterAssetsAtom = atomWithReset<string[]>([])
-export const registerAssetsAtom = atomWithReset<string[]>([])
+
+export const registerAssetsAtom = atomWithReset<RegisterAsset[]>([])
+export const registerAssetsProposedAtom = atomWithReset<string[]>([])
 
 export const backupChangesAtom = atomWithReset<BackupChanges>({
   collateralChanges: [],

--- a/src/views/governance/views/proposal/atoms.ts
+++ b/src/views/governance/views/proposal/atoms.ts
@@ -39,6 +39,7 @@ export const parametersChangesAtom = atomWithReset<ParameterChange[]>([])
 export const roleChangesAtom = atomWithReset<RoleChange[]>([])
 
 export const unregisterAssetsAtom = atomWithReset<string[]>([])
+export const registerAssetsAtom = atomWithReset<string[]>([])
 
 export const backupChangesAtom = atomWithReset<BackupChanges>({
   collateralChanges: [],

--- a/src/views/governance/views/proposal/atoms.ts
+++ b/src/views/governance/views/proposal/atoms.ts
@@ -38,6 +38,8 @@ export const parametersChangesAtom = atomWithReset<ParameterChange[]>([])
 
 export const roleChangesAtom = atomWithReset<RoleChange[]>([])
 
+export const unregisterAssetsAtom = atomWithReset<string[]>([])
+
 export const backupChangesAtom = atomWithReset<BackupChanges>({
   collateralChanges: [],
   priorityChanges: [],

--- a/src/views/governance/views/proposal/components/ProposalForm.tsx
+++ b/src/views/governance/views/proposal/components/ProposalForm.tsx
@@ -6,6 +6,7 @@ import OtherSetup from 'views/deploy/components/OtherSetup'
 import Intro from './Intro'
 import ProposalBasketSetup from './ProposalBasketSetup'
 import RolesProposal from './RolesProposal'
+import UnregisterProposal from './UnregisterProposal'
 
 const sections = [
   Intro,
@@ -13,6 +14,7 @@ const sections = [
   OtherSetup,
   RolesProposal,
   RevenueSplit,
+  UnregisterProposal,
 ]
 
 const ProposalForm = () => (

--- a/src/views/governance/views/proposal/components/ProposalForm.tsx
+++ b/src/views/governance/views/proposal/components/ProposalForm.tsx
@@ -7,6 +7,7 @@ import Intro from './Intro'
 import ProposalBasketSetup from './ProposalBasketSetup'
 import RolesProposal from './RolesProposal'
 import UnregisterProposal from './UnregisterProposal'
+import RegisterProposal from './RegisterProposal'
 
 const sections = [
   Intro,
@@ -15,6 +16,7 @@ const sections = [
   RolesProposal,
   RevenueSplit,
   UnregisterProposal,
+  RegisterProposal,
 ]
 
 const ProposalForm = () => (

--- a/src/views/governance/views/proposal/components/ProposalPreview.tsx
+++ b/src/views/governance/views/proposal/components/ProposalPreview.tsx
@@ -5,6 +5,7 @@ import ProposedParametersPreview from './ProposedParametersPreview'
 import ProposedRevenueSplitPreview from './ProposedRevenueSplitPreview'
 import ProposedRolesPreview from './ProposedRolesPreview'
 import ProposedUnregisterPreview from './ProposedUnregisterPreview'
+import ProposedRegisterPreview from './ProposedRegisterPreview'
 
 const ProposalPreview = (props: BoxProps) => (
   <Box {...props}>
@@ -14,6 +15,7 @@ const ProposalPreview = (props: BoxProps) => (
     <ProposedParametersPreview mt={4} />
     <ProposedRolesPreview mt={4} />
     <ProposedUnregisterPreview mt={4} />
+    <ProposedRegisterPreview mt={4} />
   </Box>
 )
 

--- a/src/views/governance/views/proposal/components/ProposalPreview.tsx
+++ b/src/views/governance/views/proposal/components/ProposalPreview.tsx
@@ -4,6 +4,7 @@ import ProposedBasketPreview from './ProposedBasketPreview'
 import ProposedParametersPreview from './ProposedParametersPreview'
 import ProposedRevenueSplitPreview from './ProposedRevenueSplitPreview'
 import ProposedRolesPreview from './ProposedRolesPreview'
+import ProposedUnregisterPreview from './ProposedUnregisterPreview'
 
 const ProposalPreview = (props: BoxProps) => (
   <Box {...props}>
@@ -12,6 +13,7 @@ const ProposalPreview = (props: BoxProps) => (
     <ProposedRevenueSplitPreview mt={4} />
     <ProposedParametersPreview mt={4} />
     <ProposedRolesPreview mt={4} />
+    <ProposedUnregisterPreview mt={4} />
   </Box>
 )
 

--- a/src/views/governance/views/proposal/components/ProposedRegisterPreview.tsx
+++ b/src/views/governance/views/proposal/components/ProposedRegisterPreview.tsx
@@ -1,0 +1,40 @@
+import { t } from '@lingui/macro'
+import { useAtom } from 'jotai'
+import { BoxProps } from 'theme-ui'
+import { shortenAddress } from 'utils'
+import { registerAssetsAtom } from '../atoms'
+import { ListChangePreview } from './ItemPreview'
+import PreviewBox from './PreviewBox'
+
+const ProposedRegisterPreview = (props: BoxProps) => {
+  const [assetsToRegister, setAssetsToRegister] = useAtom(registerAssetsAtom)
+
+  if (!assetsToRegister.length) {
+    return null
+  }
+
+  const handleRevert = (asset: string) => {
+    setAssetsToRegister(assetsToRegister.filter((x) => x !== asset))
+  }
+
+  return (
+    <PreviewBox
+      variant="layout.borderBox"
+      count={assetsToRegister.length}
+      title={t`Registering assets`}
+      {...props}
+    >
+      {assetsToRegister.map((asset) => (
+        <ListChangePreview
+          key={asset}
+          onRevert={() => handleRevert(asset)}
+          isNew={false}
+          value={shortenAddress(asset)}
+          mt={3}
+        />
+      ))}
+    </PreviewBox>
+  )
+}
+
+export default ProposedRegisterPreview

--- a/src/views/governance/views/proposal/components/ProposedRegisterPreview.tsx
+++ b/src/views/governance/views/proposal/components/ProposedRegisterPreview.tsx
@@ -2,33 +2,37 @@ import { t } from '@lingui/macro'
 import { useAtom } from 'jotai'
 import { BoxProps } from 'theme-ui'
 import { shortenAddress } from 'utils'
-import { registerAssetsAtom } from '../atoms'
+import { registerAssetsProposedAtom } from '../atoms'
 import { ListChangePreview } from './ItemPreview'
 import PreviewBox from './PreviewBox'
 
 const ProposedRegisterPreview = (props: BoxProps) => {
-  const [assetsToRegister, setAssetsToRegister] = useAtom(registerAssetsAtom)
+  const [proposedAssetsToRegister, setProposedAssetsToRegister] = useAtom(
+    registerAssetsProposedAtom
+  )
 
-  if (!assetsToRegister.length) {
+  if (!proposedAssetsToRegister.length) {
     return null
   }
 
   const handleRevert = (asset: string) => {
-    setAssetsToRegister(assetsToRegister.filter((x) => x !== asset))
+    setProposedAssetsToRegister(
+      proposedAssetsToRegister.filter((x) => x !== asset)
+    )
   }
 
   return (
     <PreviewBox
       variant="layout.borderBox"
-      count={assetsToRegister.length}
+      count={proposedAssetsToRegister.length}
       title={t`Registering assets`}
       {...props}
     >
-      {assetsToRegister.map((asset) => (
+      {proposedAssetsToRegister.map((asset) => (
         <ListChangePreview
           key={asset}
           onRevert={() => handleRevert(asset)}
-          isNew={false}
+          isNew={true}
           value={shortenAddress(asset)}
           mt={3}
         />

--- a/src/views/governance/views/proposal/components/ProposedUnregisterPreview.tsx
+++ b/src/views/governance/views/proposal/components/ProposedUnregisterPreview.tsx
@@ -1,0 +1,41 @@
+import { t } from '@lingui/macro'
+import { useAtom } from 'jotai'
+import { BoxProps } from 'theme-ui'
+import { shortenAddress } from 'utils'
+import { unregisterAssetsAtom } from '../atoms'
+import { ListChangePreview } from './ItemPreview'
+import PreviewBox from './PreviewBox'
+
+const ProposedUnregisterPreview = (props: BoxProps) => {
+  const [assetsToUnregister, setAssetsToUnregister] =
+    useAtom(unregisterAssetsAtom)
+
+  if (!assetsToUnregister.length) {
+    return null
+  }
+
+  const handleRevert = (asset: string) => {
+    setAssetsToUnregister(assetsToUnregister.filter((x) => x !== asset))
+  }
+
+  return (
+    <PreviewBox
+      variant="layout.borderBox"
+      count={assetsToUnregister.length}
+      title={t`Unregistering assets`}
+      {...props}
+    >
+      {assetsToUnregister.map((asset) => (
+        <ListChangePreview
+          key={asset}
+          onRevert={() => handleRevert(asset)}
+          isNew={false}
+          value={shortenAddress(asset)}
+          mt={3}
+        />
+      ))}
+    </PreviewBox>
+  )
+}
+
+export default ProposedUnregisterPreview

--- a/src/views/governance/views/proposal/components/RegisterEdit.tsx
+++ b/src/views/governance/views/proposal/components/RegisterEdit.tsx
@@ -1,0 +1,75 @@
+import { Trans } from '@lingui/macro'
+import { Input } from 'components'
+import { SmallButton } from 'components/button'
+import { useAtomValue } from 'jotai'
+import { useState } from 'react'
+import { rTokenAssetsAtom } from 'state/atoms'
+import { Box, BoxProps, Text } from 'theme-ui'
+import { isAddress } from 'utils'
+
+const NewAssetAddress = ({
+  onSave,
+  addresses,
+}: {
+  onSave(value: string): void
+  addresses: string[]
+}) => {
+  const [address, setAddress] = useState('')
+
+  const isValid = !!isAddress(address)
+  const isExisting =
+    isValid &&
+    addresses.findIndex((a) => a.toLowerCase() === address.toLowerCase()) !== -1
+
+  return (
+    <Box>
+      <Input
+        my={3}
+        autoFocus
+        value={address}
+        placeholder="Input address"
+        onChange={setAddress}
+      />
+      {((address && !isValid) || isExisting) && (
+        <Text
+          variant="error"
+          mt={-2}
+          mb={3}
+          ml={3}
+          sx={{ fontSize: 1, display: 'block' }}
+        >
+          {isExisting ? (
+            <Trans>This asset is already (being) registered</Trans>
+          ) : (
+            <Trans>Invalid asset</Trans>
+          )}
+        </Text>
+      )}
+      <SmallButton
+        disabled={!isValid || isExisting}
+        onClick={() => {
+          setAddress('')
+          onSave(address)
+        }}
+        ml={3}
+      >
+        <Trans>Save</Trans>
+      </SmallButton>
+    </Box>
+  )
+}
+
+interface RoleEditProps extends Omit<BoxProps, 'onChange'> {
+  onChange(address: string): void
+  addresses: string[]
+}
+
+const RegisterEdit = ({ onChange, addresses }: RoleEditProps) => {
+  const handleAdd = (address: string) => {
+    onChange(address)
+  }
+
+  return <NewAssetAddress onSave={handleAdd} addresses={addresses} />
+}
+
+export default RegisterEdit

--- a/src/views/governance/views/proposal/components/RegisterProposal.tsx
+++ b/src/views/governance/views/proposal/components/RegisterProposal.tsx
@@ -1,0 +1,36 @@
+import { Trans } from '@lingui/macro'
+import { Box, BoxProps, Card, Divider, Text } from 'theme-ui'
+import { useAtom, useAtomValue } from 'jotai'
+import { rTokenAssetsAtom } from 'state/atoms'
+import { registerAssetsAtom } from '../atoms'
+import useRToken from 'hooks/useRToken'
+import RegisterEdit from './RegisterEdit'
+
+const RegisterProposal = (props: BoxProps) => {
+  const [assetsToRegister, setAssetsToRegister] = useAtom(registerAssetsAtom)
+
+  const registeredErc20s = useAtomValue(rTokenAssetsAtom)
+
+  const registeredAssets = Object.values(registeredErc20s || {}).map(
+    (asset) => asset.address
+  )
+
+  const handleAssetRegister = (asset: string) => {
+    setAssetsToRegister(assetsToRegister.concat(asset))
+  }
+
+  return (
+    <Card {...props} p={4}>
+      <Text variant="sectionTitle">
+        <Trans>Register Assets</Trans>
+      </Text>
+      <Divider my={4} mx={-4} />
+      <RegisterEdit
+        onChange={handleAssetRegister}
+        addresses={[...assetsToRegister, ...registeredAssets]}
+      />
+    </Card>
+  )
+}
+
+export default RegisterProposal

--- a/src/views/governance/views/proposal/components/RegisterProposal.tsx
+++ b/src/views/governance/views/proposal/components/RegisterProposal.tsx
@@ -1,13 +1,17 @@
 import { Trans } from '@lingui/macro'
-import { Box, BoxProps, Card, Divider, Text } from 'theme-ui'
+import { Box, BoxProps, Card, Divider, Link, Text } from 'theme-ui'
 import { useAtom, useAtomValue } from 'jotai'
 import { rTokenAssetsAtom } from 'state/atoms'
-import { registerAssetsAtom } from '../atoms'
+import { registerAssetsProposedAtom } from '../atoms'
 import useRToken from 'hooks/useRToken'
 import RegisterEdit from './RegisterEdit'
 
 const RegisterProposal = (props: BoxProps) => {
-  const [assetsToRegister, setAssetsToRegister] = useAtom(registerAssetsAtom)
+  const rToken = useRToken()
+
+  const [proposedAssetsToRegister, setProposedAssetsToRegister] = useAtom(
+    registerAssetsProposedAtom
+  )
 
   const registeredErc20s = useAtomValue(rTokenAssetsAtom)
 
@@ -16,7 +20,7 @@ const RegisterProposal = (props: BoxProps) => {
   )
 
   const handleAssetRegister = (asset: string) => {
-    setAssetsToRegister(assetsToRegister.concat(asset))
+    setProposedAssetsToRegister(proposedAssetsToRegister.concat(asset))
   }
 
   return (
@@ -27,8 +31,18 @@ const RegisterProposal = (props: BoxProps) => {
       <Divider my={4} mx={-4} />
       <RegisterEdit
         onChange={handleAssetRegister}
-        addresses={[...assetsToRegister, ...registeredAssets]}
+        addresses={[...proposedAssetsToRegister, ...registeredAssets]}
       />
+      <Divider my={4} mx={-4} sx={{ borderColor: 'darkBorder' }} />
+
+      <Text variant="legend" as="p" sx={{ fontSize: 1 }} mb={1} mr={2}>
+        <Trans>
+          Registration of an asset plugin enables the RToken to price an
+          underlying ERC20 token. Where an asset plugin for the underlying token
+          already exists, the existing asset plugin is replaced with the new
+          one.
+        </Trans>
+      </Text>
     </Card>
   )
 }

--- a/src/views/governance/views/proposal/components/UnregisterEdit.tsx
+++ b/src/views/governance/views/proposal/components/UnregisterEdit.tsx
@@ -1,0 +1,82 @@
+import { Trans } from '@lingui/macro'
+import { SmallButton } from 'components/button'
+import { useAtomValue } from 'jotai'
+import { rTokenAssetsAtom } from 'state/atoms'
+import { Box, BoxProps, Text } from 'theme-ui'
+
+interface UnregisterEditProps extends Omit<BoxProps, 'onChange'> {
+  onChange(addresses: string): void
+  addresses: string[]
+  help?: string
+  compact?: boolean
+}
+
+const UnregisterEdit = ({
+  onChange,
+  help,
+  addresses,
+  compact = false,
+  ...props
+}: UnregisterEditProps) => {
+  const allAssets = useAtomValue(rTokenAssetsAtom)
+
+  const filteredAssets = Object.values(allAssets || {}).filter((asset) =>
+    addresses.includes(asset.address)
+  )
+
+  const handleRemove = (asset: string) => {
+    onChange(asset)
+  }
+
+  return (
+    <Box {...props}>
+      {!addresses.length && (
+        <Text
+          variant="legend"
+          sx={{ fontStyle: 'italic', display: 'block' }}
+          mt={3}
+          ml={3}
+        >
+          <Trans>No assets to unregister...</Trans>
+        </Text>
+      )}
+      {filteredAssets.map((asset) => (
+        <Box
+          variant="layout.verticalAlign"
+          sx={{ flexWrap: 'wrap' }}
+          key={asset.address}
+          mt={3}
+        >
+          <Box mr={2} variant="layout.verticalAlign">
+            <Box
+              ml={compact ? 0 : 1}
+              mr={3}
+              sx={{
+                height: '4px',
+                width: '4px',
+                borderRadius: '100%',
+                backgroundColor: 'text',
+              }}
+            />
+            <Box>
+              <Text sx={{ fontSize: 1, display: 'block' }} variant="legend">
+                {asset.token.symbol}
+              </Text>
+              <Text sx={{ wordBreak: 'break-word' }}>{asset.address}</Text>
+            </Box>
+          </Box>
+          <SmallButton
+            ml="auto"
+            variant="danger"
+            sx={{ backgroundColor: 'inputBorder' }}
+            onClick={() => handleRemove(asset.address)}
+          >
+            <Trans>Unregister</Trans>
+          </SmallButton>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+export default UnregisterEdit

--- a/src/views/governance/views/proposal/components/UnregisterProposal.tsx
+++ b/src/views/governance/views/proposal/components/UnregisterProposal.tsx
@@ -22,7 +22,7 @@ const UnregisterProposal = (props: BoxProps) => {
     (x) => !usedAssets.includes(x) && !assetsToUnregister.includes(x)
   )
 
-  if (!unusedAssets.length) return
+  if (!unusedAssets.length) return null
   const handleAssetRemoval = (asset: string) => {
     setAssetsToUnregister(assetsToUnregister.concat(asset))
   }

--- a/src/views/governance/views/proposal/components/UnregisterProposal.tsx
+++ b/src/views/governance/views/proposal/components/UnregisterProposal.tsx
@@ -1,0 +1,56 @@
+import { Trans } from '@lingui/macro'
+import { Box, BoxProps, Card, Divider, Link, Text } from 'theme-ui'
+import { useAtom, useAtomValue } from 'jotai'
+import { rTokenAssetsAtom } from 'state/atoms'
+import { rtokenAllActiveCollateralsAtom } from 'components/rtoken-setup/atoms'
+import UnregisterEdit from './UnregisterEdit'
+import { unregisterAssetsAtom } from '../atoms'
+import useRToken from 'hooks/useRToken'
+
+const UnregisterProposal = (props: BoxProps) => {
+  const rToken = useRToken()
+  const registeredErc20s = useAtomValue(rTokenAssetsAtom)
+  const [assetsToUnregister, setAssetsToUnregister] =
+    useAtom(unregisterAssetsAtom)
+
+  const registeredAssets = Object.values(registeredErc20s || {}).map(
+    (asset) => asset.address
+  )
+  const usedAssets = useAtomValue(rtokenAllActiveCollateralsAtom)
+
+  const unusedAssets = registeredAssets.filter(
+    (x) => !usedAssets.includes(x) && !assetsToUnregister.includes(x)
+  )
+
+  if (!unusedAssets.length) return
+  const handleAssetRemoval = (asset: string) => {
+    setAssetsToUnregister(assetsToUnregister.concat(asset))
+  }
+
+  return (
+    <Card {...props} p={4}>
+      <Text variant="sectionTitle">
+        <Trans>Unregister Assets</Trans>
+      </Text>
+      <Divider my={4} mx={-4} />
+      <UnregisterEdit addresses={unusedAssets} onChange={handleAssetRemoval} />
+      <Divider my={4} mx={-4} sx={{ borderColor: 'darkBorder' }} />
+      <Text variant="legend" as="p" sx={{ fontSize: 1 }} mb={1} mr={2}>
+        <Trans>
+          Ensure that the asset(s) you are unregistering do not have pending
+          revenue that can be
+        </Trans>{' '}
+        <Link
+          href={`#/auctions?token=${rToken?.address}`}
+          target="_blank"
+          sx={{ textDecoration: 'underline' }}
+        >
+          <Trans> auctioned</Trans>
+        </Link>
+        .
+      </Text>
+    </Card>
+  )
+}
+
+export default UnregisterProposal

--- a/src/views/governance/views/proposal/hooks/useProposalTx.ts
+++ b/src/views/governance/views/proposal/hooks/useProposalTx.ts
@@ -4,6 +4,7 @@ import {
   isAssistedUpgradeAtom,
   isNewBackupProposedAtom,
   proposalDescriptionAtom,
+  registerAssetsAtom,
   unregisterAssetsAtom,
 } from './../atoms'
 
@@ -96,6 +97,7 @@ const useProposalTx = () => {
   const parameterChanges = useAtomValue(parametersChangesAtom)
   const roleChanges = useAtomValue(roleChangesAtom)
   const assetsToUnregister = useAtomValue(unregisterAssetsAtom)
+  const assetsToRegister = useAtomValue(registerAssetsAtom)
   const newBackup = useAtomValue(isNewBackupProposedAtom)
   const newBasket = useAtomValue(isNewBasketProposedAtom)
   const basket = useAtomValue(basketAtom)
@@ -263,6 +265,17 @@ const useProposalTx = () => {
           encodeFunctionData({
             abi: AssetRegistry,
             functionName: 'unregister',
+            args: [asset as `0x${string}`],
+          })
+        )
+      }
+
+      for (const asset of assetsToRegister) {
+        addresses.push(contracts.assetRegistry.address)
+        calls.push(
+          encodeFunctionData({
+            abi: AssetRegistry,
+            functionName: 'register',
             args: [asset as `0x${string}`],
           })
         )

--- a/src/views/governance/views/proposal/hooks/useProposalTx.ts
+++ b/src/views/governance/views/proposal/hooks/useProposalTx.ts
@@ -265,20 +265,13 @@ const useProposalTx = () => {
           encodeFunctionData({
             abi: AssetRegistry,
             functionName: 'unregister',
-            args: [asset as `0x${string}`],
+            args: [asset as Address],
           })
         )
       }
 
       for (const asset of assetsToRegister) {
-        addresses.push(contracts.assetRegistry.address)
-        calls.push(
-          encodeFunctionData({
-            abi: AssetRegistry,
-            functionName: 'register',
-            args: [asset as `0x${string}`],
-          })
-        )
+        addToRegistry(asset.asset, asset.erc20)
       }
 
       /* ########################## 

--- a/src/views/governance/views/proposal/hooks/useProposalTx.ts
+++ b/src/views/governance/views/proposal/hooks/useProposalTx.ts
@@ -4,6 +4,7 @@ import {
   isAssistedUpgradeAtom,
   isNewBackupProposedAtom,
   proposalDescriptionAtom,
+  unregisterAssetsAtom,
 } from './../atoms'
 
 import AssetRegistry from 'abis/AssetRegistry'
@@ -94,6 +95,7 @@ const useProposalTx = () => {
   const revenueChanges = useAtomValue(revenueSplitChangesAtom)
   const parameterChanges = useAtomValue(parametersChangesAtom)
   const roleChanges = useAtomValue(roleChangesAtom)
+  const assetsToUnregister = useAtomValue(unregisterAssetsAtom)
   const newBackup = useAtomValue(isNewBackupProposedAtom)
   const newBasket = useAtomValue(isNewBasketProposedAtom)
   const basket = useAtomValue(basketAtom)
@@ -251,6 +253,17 @@ const useProposalTx = () => {
             abi: (isGuardian ? Timelock : Main) as any,
             functionName: roleChange.isNew ? 'grantRole' : 'revokeRole',
             args: [ROLES[roleChange.role], roleChange.address],
+          })
+        )
+      }
+
+      for (const asset of assetsToUnregister) {
+        addresses.push(contracts.assetRegistry.address)
+        calls.push(
+          encodeFunctionData({
+            abi: AssetRegistry,
+            functionName: 'unregister',
+            args: [asset as `0x${string}`],
           })
         )
       }

--- a/src/views/governance/views/proposal/hooks/useRegisterAssets.ts
+++ b/src/views/governance/views/proposal/hooks/useRegisterAssets.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react'
+import { useAtomValue } from 'jotai'
+import AssetAbi from 'abis/AssetAbi'
+import { getContract } from 'wagmi/actions'
+import { chainIdAtom } from 'state/atoms'
+import { registerAssetsProposedAtom } from '../atoms'
+import { Address } from 'viem'
+
+export interface RegisterAsset {
+  asset: Address
+  erc20: Address | undefined
+}
+
+const useRegisterAssets = () => {
+  const proposedAssetsToRegister = useAtomValue(registerAssetsProposedAtom)
+  const chainId = useAtomValue(chainIdAtom)
+  const [assetsToRegister, setRegisterAssets] = useState<RegisterAsset[]>([])
+
+  useEffect(() => {
+    const fetchERC20Address = async (asset: Address) => {
+      const contract = getContract({
+        address: asset as Address,
+        abi: AssetAbi,
+        chainId: chainId,
+      })
+
+      try {
+        const erc20 = await contract.read.erc20()
+        return { asset, erc20 }
+      } catch (e) {
+        console.error('Error fetching underlying erc20', e)
+        return { asset, erc20: undefined }
+      }
+    }
+
+    const fetchAllERC20s = async () => {
+      const fetchPromises = (proposedAssetsToRegister as Address[]).map(
+        fetchERC20Address
+      )
+      const results = await Promise.all(fetchPromises)
+      setRegisterAssets(results)
+    }
+
+    if (proposedAssetsToRegister.length > 0) {
+      fetchAllERC20s()
+    }
+  }, [proposedAssetsToRegister, chainId])
+
+  return assetsToRegister
+}
+
+export default useRegisterAssets

--- a/src/views/governance/views/proposal/hooks/useRegisterAssets.ts
+++ b/src/views/governance/views/proposal/hooks/useRegisterAssets.ts
@@ -43,6 +43,8 @@ const useRegisterAssets = () => {
 
     if (proposedAssetsToRegister.length > 0) {
       fetchAllERC20s()
+    } else {
+      setRegisterAssets([])
     }
   }, [proposedAssetsToRegister, chainId])
 

--- a/src/views/governance/views/proposal/updater.tsx
+++ b/src/views/governance/views/proposal/updater.tsx
@@ -26,6 +26,7 @@ import {
   parametersChangesAtom,
   revenueSplitChangesAtom,
   roleChangesAtom,
+  unregisterAssetsAtom,
 } from './atoms'
 import useBackupChanges from './hooks/useBackupChanges'
 import useBasketChanges from './hooks/useBasketChanges'
@@ -102,6 +103,7 @@ export const ChangesUpdater = () => {
   const roleChanges = useRoleChanges()
   const isNewBasket = useAtomValue(isNewBasketProposedAtom)
   const isNewBackup = useAtomValue(isNewBackupProposedAtom)
+  const assetsToUnregister = useAtomValue(unregisterAssetsAtom)
   // Valid listeners
   const isBasketValid = useAtomValue(isBasketValidAtom)
   const isRevenueSplitValid = useAtomValue(isRevenueValidAtom)
@@ -144,6 +146,7 @@ export const ChangesUpdater = () => {
       !revenueChanges.count &&
       !parameterChanges.length &&
       !roleChanges.length &&
+      !assetsToUnregister.length &&
       !isNewBasket
     ) {
       setValidState(false)
@@ -161,6 +164,7 @@ export const ChangesUpdater = () => {
     revenueChanges,
     parameterChanges,
     roleChanges,
+    assetsToUnregister,
     isValid,
   ])
 

--- a/src/views/governance/views/proposal/updater.tsx
+++ b/src/views/governance/views/proposal/updater.tsx
@@ -34,6 +34,7 @@ import useBasketChanges from './hooks/useBasketChanges'
 import useParametersChanges from './hooks/useParametersChanges'
 import useRevenueSplitChanges from './hooks/useRevenueSplitChanges'
 import useRoleChanges from './hooks/useRoleChanges'
+import useRegisterAssets from './hooks/useRegisterAssets'
 
 export const RTokenDataUpdater = () => {
   // Setup atoms
@@ -102,10 +103,11 @@ export const ChangesUpdater = () => {
   const revenueChanges = useRevenueSplitChanges()
   const parameterChanges = useParametersChanges()
   const roleChanges = useRoleChanges()
+  const assetsToRegister = useRegisterAssets()
   const isNewBasket = useAtomValue(isNewBasketProposedAtom)
   const isNewBackup = useAtomValue(isNewBackupProposedAtom)
   const assetsToUnregister = useAtomValue(unregisterAssetsAtom)
-  const assetsToRegister = useAtomValue(registerAssetsAtom)
+
   // Valid listeners
   const isBasketValid = useAtomValue(isBasketValidAtom)
   const isRevenueSplitValid = useAtomValue(isRevenueValidAtom)
@@ -120,6 +122,7 @@ export const ChangesUpdater = () => {
   const setRoleChanges = useSetAtom(roleChangesAtom)
   const setValidState = useSetAtom(isProposalValidAtom)
   const setBasketChanges = useSetAtom(basketChangesAtom)
+  const setRegisterAssets = useSetAtom(registerAssetsAtom)
 
   useEffect(() => {
     setBasketChanges(basketChanges)
@@ -140,6 +143,10 @@ export const ChangesUpdater = () => {
   useEffect(() => {
     setRoleChanges(roleChanges)
   }, [roleChanges])
+
+  useEffect(() => {
+    setRegisterAssets(assetsToRegister)
+  }, [assetsToRegister])
 
   useEffect(() => {
     // Check if there is any change to be proposed to mark it as valid

--- a/src/views/governance/views/proposal/updater.tsx
+++ b/src/views/governance/views/proposal/updater.tsx
@@ -24,6 +24,7 @@ import {
   isNewBasketProposedAtom,
   isProposalValidAtom,
   parametersChangesAtom,
+  registerAssetsAtom,
   revenueSplitChangesAtom,
   roleChangesAtom,
   unregisterAssetsAtom,
@@ -104,6 +105,7 @@ export const ChangesUpdater = () => {
   const isNewBasket = useAtomValue(isNewBasketProposedAtom)
   const isNewBackup = useAtomValue(isNewBackupProposedAtom)
   const assetsToUnregister = useAtomValue(unregisterAssetsAtom)
+  const assetsToRegister = useAtomValue(registerAssetsAtom)
   // Valid listeners
   const isBasketValid = useAtomValue(isBasketValidAtom)
   const isRevenueSplitValid = useAtomValue(isRevenueValidAtom)
@@ -147,6 +149,7 @@ export const ChangesUpdater = () => {
       !parameterChanges.length &&
       !roleChanges.length &&
       !assetsToUnregister.length &&
+      !assetsToRegister.length &&
       !isNewBasket
     ) {
       setValidState(false)
@@ -165,6 +168,7 @@ export const ChangesUpdater = () => {
     parameterChanges,
     roleChanges,
     assetsToUnregister,
+    assetsToRegister,
     isValid,
   ])
 


### PR DESCRIPTION
Caveat is that this list will in inaccurate for RTokens that have not upgraded to the most recent version (and thus their assets will not be present in the `mainnet.json` mainfest)

<img width="527" alt="image" src="https://github.com/lc-labs/register/assets/71284258/4f29c00c-8de4-4e9f-83f0-ce805762b167">
