### PR TITLE
Parse governance change params

### DIFF
--- a/src/views/governance/views/proposal/hooks/useProposalTx.ts
+++ b/src/views/governance/views/proposal/hooks/useProposalTx.ts
@@ -34,6 +34,7 @@ import {
   Hex,
   encodeFunctionData,
   parseEther,
+  parseUnits,
   stringToHex,
   zeroAddress,
 } from 'viem'
@@ -49,18 +50,20 @@ import {
 } from '../atoms'
 import useUpgradeHelper from './useUpgradeHelper'
 
-// const paramParse: { [x: string]: (v: string) => bigint | number } = {
-//   minTradeVolume: parseEther,
-//   rTokenMaxTradeVolume: parseEther,
-//   rewardRatio: parseEther,
-//   unstakingDelay: Number,
-//   tradingDelay: Number,
-//   auctionLength: Number,
-//   backingBuffer: parsePercent,
-//   maxTradeSlippage: parsePercent,
-//   shortFreeze: Number,
-//   longFreeze: Number,
-// }
+const paramParse: { [x: string]: (v: string) => bigint | number } = {
+  minTradeVolume: parseEther,
+  rTokenMaxTradeVolume: parseEther,
+  rewardRatio: parseEther,
+  withdrawalLeak: (v) => parseUnits(v, 16),
+  unstakingDelay: Number,
+  tradingDelay: Number,
+  auctionLength: Number,
+  backingBuffer: parsePercent,
+  maxTradeSlippage: parsePercent,
+  shortFreeze: Number,
+  longFreeze: Number,
+  warmupPeriod: Number,
+}
 
 const ROLES: { [x: string]: string } = {
   longFreezers:
@@ -225,11 +228,14 @@ const useProposalTx = () => {
           for (const contract of parameterMap[paramChange.field as ParamName]) {
             const { address, ...data } = contract
 
+            const proposedParam = paramParse[paramChange.field]
+              ? paramParse[paramChange.field](paramChange.proposed)
+              : paramChange.proposed
             addresses.push(address)
             calls.push(
               encodeFunctionData({
                 ...(data as any),
-                args: [paramChange.proposed],
+                args: [proposedParam],
               })
             )
           }


### PR DESCRIPTION
Previously, numerical parameter changes weren't being parsed correctly, leading to such errors, which this PR fixes: 
<img width="620" alt="image" src="https://github.com/lc-labs/register/assets/71284258/0ac00ada-6884-4d2a-ae72-d561acc1e7c9">
<img width="348" alt="image" src="https://github.com/lc-labs/register/assets/71284258/68736531-6f4c-4bce-9a46-eafd9205260b">
