### PR TITLE
chore: pin axios to 1.13.2 to avoid compromised 1.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1986,15 +1986,6 @@
         }
       }
     },
-    "node_modules/@coinbase/cdp-sdk/node_modules/axios": {
-      "version": "1.13.2",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@coinbase/cdp-sdk/node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
@@ -11229,10 +11220,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios-retry": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
   },
   "overrides": {
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "axios": "1.13.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260120.0",


### PR DESCRIPTION
## Summary
- Pin axios to 1.13.2 via npm overrides to prevent transitive dependencies (e.g. `@coinbase/cdp-sdk`) from resolving to the compromised `axios@1.14.1`