### PR TITLE
chore: prevent redeem during rebalance yield-dtf

### DIFF
--- a/src/views/yield-dtf/issuance/components/redeem/RedeemInput.tsx
+++ b/src/views/yield-dtf/issuance/components/redeem/RedeemInput.tsx
@@ -15,7 +15,7 @@ const RedeemInput = (props: Partial<TransactionInputProps>) => {
       title={t`Redeem`}
       placeholder={t`Redeem amount`}
       amountAtom={redeemAmountAtom}
-      maxAmount={max.balance}
+      maxAmount={props.disabled ? '' : max.balance}
       disabled={frozen}
       {...props}
     />

--- a/src/views/yield-dtf/issuance/components/redeem/RedemptionQuote.tsx
+++ b/src/views/yield-dtf/issuance/components/redeem/RedemptionQuote.tsx
@@ -45,36 +45,38 @@ const CurrentRedemptionQuote = () => {
   )
 }
 
-const RedemptionQuoteSelector = () => {
-  const { basketNonce } = useAtomValue(rTokenStateAtom)
-  const selectedNonce = useAtomValue(redeemNonceAtom)
-  const setNonceSelection = useSetAtom(customRedeemModalAtom)
+// const RedemptionQuoteSelector = () => {
+//   const { basketNonce } = useAtomValue(rTokenStateAtom)
+//   const selectedNonce = useAtomValue(redeemNonceAtom)
+//   const setNonceSelection = useSetAtom(customRedeemModalAtom)
 
-  return (
-    <div
-      className="mt-4 flex items-center border border-input rounded-md cursor-pointer px-2 py-4"
-      onClick={() => setNonceSelection(true)}
-    >
-      <OverviewIcon />
-      <span className="ml-2 mr-auto">
-        {basketNonce === selectedNonce
-          ? 'Redeem with current basket'
-          : 'Redeem with previous basket'}
-      </span>
-      <ChevronRight size={14} />
-    </div>
-  )
-}
+//   return (
+//     <div
+//       className="mt-4 flex items-center border border-input rounded-md cursor-pointer px-2 py-4"
+//       onClick={() => setNonceSelection(true)}
+//     >
+//       <OverviewIcon />
+//       <span className="ml-2 mr-auto">
+//         {basketNonce === selectedNonce
+//           ? 'Redeem with current basket'
+//           : 'Redeem with previous basket'}
+//       </span>
+//       <ChevronRight size={14} />
+//     </div>
+//   )
+// }
 
 const RedemptionQuote = () => {
-  const { isCollaterized } = useAtomValue(rTokenStateAtom)
-  const { issuance: isLegacy } = useAtomValue(isModuleLegacyAtom)
+  // const { isCollaterized } = useAtomValue(rTokenStateAtom)
+  // const { issuance: isLegacy } = useAtomValue(isModuleLegacyAtom)
 
-  if (isCollaterized || isLegacy) {
-    return <CurrentRedemptionQuote />
-  }
+  // if (isCollaterized || isLegacy) {
+  //   return <CurrentRedemptionQuote />
+  // }
 
-  return <RedemptionQuoteSelector />
+  // return <RedemptionQuoteSelector />
+
+  return <CurrentRedemptionQuote />
 }
 
 export default RedemptionQuote

--- a/src/views/yield-dtf/issuance/components/redeem/index.tsx
+++ b/src/views/yield-dtf/issuance/components/redeem/index.tsx
@@ -13,24 +13,27 @@ import { customRedeemNonceAtom, redeemNonceAtom } from './atoms'
 const Redeem = () => {
   const rToken = useRToken()
   const [confirming, setConfirming] = useState(false)
+  const { isCollaterized } = useAtomValue(rTokenStateAtom)
   const isValid = useAtomValue(isValidRedeemAmountAtom)
-  const { basketNonce, isCollaterized } = useAtomValue(rTokenStateAtom)
-  const selectedNonce = useAtomValue(redeemNonceAtom)
-  const setSelectedNonce = useSetAtom(customRedeemNonceAtom)
 
-  useEffect(() => {
-    if (!isCollaterized && basketNonce > 0 && basketNonce === selectedNonce) {
-      setSelectedNonce(basketNonce - 1)
-    }
-  }, [basketNonce, isCollaterized])
+  // TODO: Disable custom redeems
+  // const { basketNonce, isCollaterized } = useAtomValue(rTokenStateAtom)
+  // const selectedNonce = useAtomValue(redeemNonceAtom)
+  // const setSelectedNonce = useSetAtom(customRedeemNonceAtom)
+
+  // useEffect(() => {
+  //   if (!isCollaterized && basketNonce > 0 && basketNonce === selectedNonce) {
+  //     setSelectedNonce(basketNonce - 1)
+  //   }
+  // }, [basketNonce, isCollaterized])
 
   return (
     <>
       {confirming && <ConfirmRedemption onClose={() => setConfirming(false)} />}
       <Card className="p-4 h-fit relative border-2 border-secondary">
-        <RedeemInput compact={false} />
+        <RedeemInput disabled={!isCollaterized} compact={false} />
         <Button
-          disabled={!isValid}
+          disabled={!isValid || !isCollaterized}
           className="w-full mt-4"
           onClick={() => setConfirming(true)}
         >

--- a/src/views/yield-dtf/issuance/components/warnings/index.tsx
+++ b/src/views/yield-dtf/issuance/components/warnings/index.tsx
@@ -51,8 +51,8 @@ export const CollateralizationBanner = ({
   return (
     <WarningBanner
       className={className}
-      title="RToken basket is under re-collateralization."
-      description="For redemptions, please wait until the process is complete or manually redeem using the previous basket."
+      title="DTF Basket is under re-collateralization."
+      description="For redemptions, please wait until the process is complete."
     />
   )
 }

--- a/src/views/yield-dtf/issuance/components/zapV2/RTokenZapIssuance.tsx
+++ b/src/views/yield-dtf/issuance/components/zapV2/RTokenZapIssuance.tsx
@@ -19,7 +19,7 @@ const InputOutputSeparator = () => (
 
 const RTokenZapIssuance = ({ disableRedeem }: { disableRedeem: boolean }) => {
   return (
-    <Card className="lg:mr-6 rounded-3xl bg-card shadow-lg h-fit">
+    <Card className="rounded-3xl bg-card shadow-lg h-fit">
       <div className="flex items-center border-b border-border p-6">
         <ZapTabs />
       </div>

--- a/src/views/yield-dtf/issuance/components/zapV2/ZapRedeemDisabled.tsx
+++ b/src/views/yield-dtf/issuance/components/zapV2/ZapRedeemDisabled.tsx
@@ -6,16 +6,16 @@ const ZapRedeemDisabled = ({ disableRedeem }: { disableRedeem: boolean }) => {
   if (operation !== 'redeem' || !disableRedeem) return null
 
   return (
-    <div className="absolute top-0 right-0 bottom-0 left-0 flex flex-col gap-2 justify-center items-center bg-secondary rounded-3xl opacity-95 z-[1]">
+    <div className="absolute top-0 right-0 bottom-0 left-0 flex flex-col gap-2 justify-center items-center bg-secondary rounded-br-3xl rounded-bl-3xl opacity-95 z-[1]">
       <span className="text-xl">
-        Zap Redeem not available during re-collateralization
+        Redeems not available during re-collateralization
       </span>
-      <Button
+      {/* <Button
         size="sm"
         onClick={() => setZapEnabled(false)}
       >
         Switch to manual minting
-      </Button>
+      </Button> */}
     </div>
   )
 }

--- a/src/views/yield-dtf/issuance/index.tsx
+++ b/src/views/yield-dtf/issuance/index.tsx
@@ -33,47 +33,47 @@ const IssuanceMethods = () => {
 
   return (
     <>
-    <DeprecatedBanner className="mb-4" />
-    <div className="grid grid-cols-1 xl:grid-cols-[1fr_480px] gap-0 lg:gap-4 xl:gap-5">
-      {zapEnabled && chainId !== ChainId.Arbitrum ? (
-        <div className="flex flex-col gap-6">
-          <CollateralizationBanner className="ml-6 -mb-6 mt-6" />
-          <MaintenanceBanner className="ml-6 -mb-6 mt-6" />
-          <RTokenZapIssuance disableRedeem={!isCollaterized} />
-          <ZapToggleBottom setZapEnabled={setZapEnabled} />
-        </div>
-      ) : (
-        <div>
-          <CollateralizationBanner className="mb-4" />
-          <MaintenanceBanner className="mb-4" />
-          <DisabledArbitrumBanner className="mb-4" />
-          {chainId !== ChainId.Arbitrum && (
-            <ZapToggle zapEnabled={zapEnabled} setZapEnabled={setZapEnabled} />
-          )}
-          <DisabledByGeolocationMessage className="mb-6" />
-          {isDeprecated ? (
-            <div className="mb-1 sm:mb-6">
-              <Redeem />
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1 sm:gap-6 mb-1 sm:mb-6">
-              <Issue />
-              <Redeem />
-            </div>
-          )}
-          <Balances />
-        </div>
-      )}
-      <div className="border-l-0 xl:border-l xl:border-border min-h-auto xl:min-h-[calc(100vh-73px)]">
-        <IssuanceInfo className="mb-1 sm:mb-0" />
-        {!zapEnabled && (
-          <>
-            <Separator className="my-0 border-secondary" />
-            <About />
-          </>
+      <DeprecatedBanner className="mb-4" />
+      <div className="grid grid-cols-1 xl:grid-cols-[1fr_480px] gap-0 lg:gap-4 xl:gap-5">
+        {zapEnabled && chainId !== ChainId.Arbitrum ? (
+          <div className="flex flex-col gap-4">
+            <CollateralizationBanner />
+            <MaintenanceBanner />
+            <RTokenZapIssuance disableRedeem={!isCollaterized} />
+            <ZapToggleBottom setZapEnabled={setZapEnabled} />
+          </div>
+        ) : (
+          <div>
+            <CollateralizationBanner className="mb-4" />
+            <MaintenanceBanner className="mb-4" />
+            <DisabledArbitrumBanner className="mb-4" />
+            {chainId !== ChainId.Arbitrum && (
+              <ZapToggle zapEnabled={zapEnabled} setZapEnabled={setZapEnabled} />
+            )}
+            <DisabledByGeolocationMessage className="mb-6" />
+            {isDeprecated ? (
+              <div className="mb-1 sm:mb-6">
+                <Redeem />
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-1 sm:gap-6 mb-1 sm:mb-6">
+                <Issue />
+                <Redeem />
+              </div>
+            )}
+            <Balances />
+          </div>
         )}
+        <div className="border-l-0 xl:border-l xl:border-border min-h-auto xl:min-h-[calc(100vh-73px)]">
+          <IssuanceInfo className="mb-1 sm:mb-0" />
+          {!zapEnabled && (
+            <>
+              <Separator className="my-0 border-secondary" />
+              <About />
+            </>
+          )}
+        </div>
       </div>
-    </div>
     </>
   )
 }


### PR DESCRIPTION
Prevents users from redeeming Yield DTFs while a rebalance is in progress. Disables redeem UI and shows appropriate warnings during active rebalances.