### PR TITLE
Add per-proposal wallet vote status to Governance Explorer

### DIFF
--- a/src/views/explorer/components/governance/atoms.ts
+++ b/src/views/explorer/components/governance/atoms.ts
@@ -7,6 +7,7 @@ export interface ProposalRecord {
   id: string
   description: string
   creationTime: string
+  userVote: string | null
   votingState: VotingState
   governance: string
   forWeightedVotes: string

--- a/src/views/explorer/components/governance/index.tsx
+++ b/src/views/explorer/components/governance/index.tsx
@@ -7,7 +7,9 @@ import { Table } from '@/components/ui/legacy-table'
 import TokenItem from 'components/token-item'
 import dayjs from 'dayjs'
 import useRTokenLogo from 'hooks/useRTokenLogo'
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
+import { walletAtom } from 'state/atoms'
 import { getFolioRoute, getProposalTitle, getTokenRoute } from 'utils'
 import { PROPOSAL_STATES, ROUTES, formatConstant } from 'utils/constants'
 import useProposalsData, { type ProposalRecord } from './use-proposals-data'
@@ -45,8 +47,14 @@ const getProposalRoute = (proposal: ProposalRecord) => {
 
 const columnHelper = createColumnHelper<ProposalRecord>()
 
+const formatVoteChoice = (choice: string | null) => {
+  if (!choice) return null
+  return choice.toLowerCase().replace(/^\w/, (char) => char.toUpperCase())
+}
+
 const ExploreGovernance = () => {
   const data = useProposalsData()
+  const wallet = useAtomValue(walletAtom)
 
   const columns = useMemo(
     () => [
@@ -99,8 +107,17 @@ const ExploreGovernance = () => {
           </span>
         ),
       }),
+      columnHelper.accessor('userVote', {
+        header: t`Your Vote`,
+        cell: (data) => {
+          const choice = formatVoteChoice(data.getValue())
+          if (!wallet) return <span className="text-muted-foreground">Connect wallet</span>
+
+          return <span>{choice || 'Not voted'}</span>
+        },
+      }),
     ],
-    []
+    [wallet]
   )
 
   return (

--- a/src/views/explorer/components/governance/use-proposals-data.ts
+++ b/src/views/explorer/components/governance/use-proposals-data.ts
@@ -7,6 +7,7 @@ import { gql } from 'graphql-request'
 import { useMultichainQuery } from 'hooks/use-query'
 import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
+import { walletAtom } from 'state/atoms'
 import { ChainId } from 'utils/chains'
 import { LISTED_RTOKEN_ADDRESSES, supportedChainList } from 'utils/constants'
 import { Address, formatEther, getAddress, zeroAddress } from 'viem'
@@ -19,7 +20,7 @@ export type { ProposalRecord } from './atoms'
 // --- Yield DTF query ---
 
 const yieldProposalsQuery = gql`
-  query getAllProposals {
+  query getAllProposals($voter: String!) {
     proposals(orderBy: creationTime, orderDirection: desc, first: 1000) {
       id
       description
@@ -43,6 +44,9 @@ const yieldProposalsQuery = gql`
           }
         }
       }
+      votes(where: { voter_: { address: $voter } }) {
+        choice
+      }
     }
   }
 `
@@ -50,7 +54,7 @@ const yieldProposalsQuery = gql`
 // --- Index DTF queries ---
 
 const indexProposalsQuery = gql`
-  query getAllIndexProposals {
+  query getAllIndexProposals($voter: String!) {
     proposals(orderBy: creationTime, orderDirection: desc, first: 1000) {
       id
       description
@@ -65,6 +69,9 @@ const indexProposalsQuery = gql`
       executionETA
       governance {
         id
+      }
+      votes(where: { voter_: { address: $voter } }) {
+        choice
       }
     }
   }
@@ -107,6 +114,7 @@ type IndexProposalsResponse = {
     voteEnd: string
     executionETA?: string
     governance: { id: string }
+    votes: { choice: string }[]
   }[]
 }
 
@@ -132,6 +140,7 @@ type DTFInfo = {
 
 const useIndexDTFProposals = () => {
   const { data: dtfList } = useIndexDTFList()
+  const account = useAtomValue(walletAtom)
 
   // Build per-chain address lists from whitelisted DTFs
   const dtfsByChain = useMemo(() => {
@@ -162,7 +171,7 @@ const useIndexDTFProposals = () => {
   }, [dtfList])
 
   return useQuery({
-    queryKey: ['explorer-index-dtf-proposals', dtfsByChain],
+    queryKey: ['explorer-index-dtf-proposals', dtfsByChain, account],
     queryFn: async () => {
       if (!dtfsByChain || !dtfInfoMap) return null
 
@@ -176,7 +185,9 @@ const useIndexDTFProposals = () => {
 
           // Fetch proposals + governance IDs for whitelisted DTFs in parallel
           const [proposalsRes, governanceRes] = await Promise.all([
-            client.request<IndexProposalsResponse>(indexProposalsQuery),
+            client.request<IndexProposalsResponse>(indexProposalsQuery, {
+              voter: account?.toLowerCase() ?? zeroAddress,
+            }),
             client.request<IndexDTFGovernanceResponse>(indexDtfGovernanceQuery, {
               ids: addresses,
             }),
@@ -214,7 +225,10 @@ const useIndexDTFProposals = () => {
 const useProposalsData = () => {
   const blocks = useBlockChains()
   const filters = useAtomValue(filtersAtom)
-  const { data: yieldData } = useMultichainQuery(yieldProposalsQuery)
+  const account = useAtomValue(walletAtom)
+  const { data: yieldData } = useMultichainQuery(yieldProposalsQuery, {
+    voter: account?.toLowerCase() ?? zeroAddress,
+  })
   const { data: indexData } = useIndexDTFProposals()
 
   return useMemo(() => {
@@ -244,6 +258,7 @@ const useProposalsData = () => {
             id: entry.id,
             description: entry.description,
             creationTime: entry.creationTime,
+            userVote: entry.votes?.[0]?.choice ?? null,
             governance: rToken.id,
             forWeightedVotes: entry.forWeightedVotes,
             againstWeightedVotes: entry.againstWeightedVotes,
@@ -298,6 +313,7 @@ const useProposalsData = () => {
             id: entry.id,
             description: entry.description,
             creationTime: entry.creationTime,
+            userVote: entry.votes?.[0]?.choice ?? null,
             governance: govId,
             forWeightedVotes: entry.forWeightedVotes,
             againstWeightedVotes: entry.againstWeightedVotes,


### PR DESCRIPTION
### Motivation
- Provide a quick way for connected users to see if and how they've voted on each proposal from the Governance Explorer so active governance is easier across DTFs.

### Description
- Add a `userVote` field to the `ProposalRecord` model (`src/views/explorer/components/governance/atoms.ts`).
- Update the Yield and Index GraphQL list queries to accept a `voter` variable and fetch the connected wallet's `votes` choice per proposal, and thread the connected address into those queries (`src/views/explorer/components/governance/use-proposals-data.ts`).
- Populate `userVote` when assembling proposal rows and add the connected-account into query keys so results update when the wallet changes (`use-proposals-data`).
- Add a new `Your Vote` column to the Governance Explorer table that shows `Connect wallet` when no wallet is present, `Not voted` when connected but no vote exists, and a normalized vote choice when present (`src/views/explorer/components/governance/index.tsx`).

### Testing
- Ran TypeScript checks with `pnpm -s typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e640d512f883248e01fa45d4d2d1e4)