### PR TITLE
chore: filter deprecated DTFs from /earn opportunities

### DIFF
--- a/src/views/earn/atoms.ts
+++ b/src/views/earn/atoms.ts
@@ -1,0 +1,5 @@
+import { atom } from 'jotai'
+
+// Populated by the updater in src/views/earn/index.tsx.
+// Shared across /earn sub-views so filter atoms can drop deprecated DTFs.
+export const deprecatedDTFAddressesAtom = atom<Set<string>>(new Set<string>())

--- a/src/views/earn/index.tsx
+++ b/src/views/earn/index.tsx
@@ -1,8 +1,11 @@
+import { useDeprecatedAddresses } from '@/hooks/use-dtf-status'
 import { cn } from '@/lib/utils'
 import { ROUTES } from '@/utils/constants'
+import { useSetAtom } from 'jotai'
 import mixpanel from 'mixpanel-browser/src/loaders/loader-module-core'
 import { useEffect } from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
+import { deprecatedDTFAddressesAtom } from './atoms'
 
 const EARN_ROUTES = [
   {
@@ -46,6 +49,17 @@ const EarnNavigation = () => {
   )
 }
 
+const DeprecatedDTFsUpdater = () => {
+  const deprecated = useDeprecatedAddresses()
+  const setDeprecated = useSetAtom(deprecatedDTFAddressesAtom)
+
+  useEffect(() => {
+    setDeprecated(deprecated)
+  }, [deprecated, setDeprecated])
+
+  return null
+}
+
 const Earn = () => {
   useEffect(() => {
     mixpanel.track('Visted Earn Page', {})
@@ -55,6 +69,7 @@ const Earn = () => {
     <div className="container px-0 lg:px-4 mb-4">
       <EarnNavigation />
       <Outlet />
+      <DeprecatedDTFsUpdater />
     </div>
   )
 }

--- a/src/views/earn/views/defi/atoms.ts
+++ b/src/views/earn/views/defi/atoms.ts
@@ -1,3 +1,4 @@
+import { deprecatedDTFAddressesAtom } from '@/views/earn/atoms'
 import { atom } from 'jotai'
 import { atomWithReset } from 'jotai/utils'
 import { poolsAtom } from 'state/pools/atoms'
@@ -25,11 +26,21 @@ export const filteredPoolsAtom = atom((get) => {
   const search = get(poolSearchFilterAtom).trim().toLowerCase()
   const filters = get(poolFilterAtom)
   const chains = get(poolChainsFilterAtom)
+  const deprecated = get(deprecatedDTFAddressesAtom)
 
   return pools.filter((pool) => {
     if (
       !chains.length ||
       !chains.includes(NETWORKS[pool.chain.toLowerCase()].toString())
+    ) {
+      return false
+    }
+
+    // Deprecated filter: drop pools whose underlying tokens include a deprecated DTF
+    if (
+      pool.underlyingTokens.some((token) =>
+        deprecated.has(token.address.toLowerCase())
+      )
     ) {
       return false
     }

--- a/src/views/earn/views/defi/components/featured-pools.tsx
+++ b/src/views/earn/views/defi/components/featured-pools.tsx
@@ -1,21 +1,29 @@
-import FeaturedPoolItem from './featured-pool-item'
+import { deprecatedDTFAddressesAtom } from '@/views/earn/atoms'
 import { useAtomValue } from 'jotai'
-import { poolsAtom } from 'state/pools/atoms'
 import { useMemo } from 'react'
+import { poolsAtom } from 'state/pools/atoms'
+import FeaturedPoolItem from './featured-pool-item'
 
 const FeaturedPools = () => {
   const pools = useAtomValue(poolsAtom)
+  const deprecated = useAtomValue(deprecatedDTFAddressesAtom)
 
   const selectedPools = useMemo(() => {
     const handPickedPools = pools
-      .filter((pool) => pool.symbol !== 'RSR-WETH')
+      .filter(
+        (pool) =>
+          pool.symbol !== 'RSR-WETH' &&
+          !pool.underlyingTokens.some((token) =>
+            deprecated.has(token.address.toLowerCase())
+          )
+      )
       .sort((a, b) => b.apy - a.apy)
       .slice(0, 3)
 
     return handPickedPools.length === 3
       ? handPickedPools
       : [undefined, undefined, undefined]
-  }, [pools])
+  }, [pools, deprecated])
 
   return (
     <div className="bg-secondary p-1 rounded-4xl">

--- a/src/views/earn/views/index-dtf/atoms.ts
+++ b/src/views/earn/views/index-dtf/atoms.ts
@@ -2,6 +2,7 @@ import { ChainId } from '@/utils/chains'
 import { atom } from 'jotai'
 import { VoteLockPosition } from './hooks/use-vote-lock-positions'
 import { IndexDTFItem } from '@/hooks/useIndexDTFList'
+import { deprecatedDTFAddressesAtom } from '@/views/earn/atoms'
 
 export const voteLockPositionsAtom = atom<VoteLockPosition[] | undefined>(
   undefined
@@ -40,12 +41,21 @@ export const filteredVoteLockPositionsAtom = atom((get) => {
   const search = get(searchFilterAtom).toLowerCase()
   const chains = get(chainsFilterAtom)
   const selectedDtfs = get(dtfsFilterAtom)
+  const deprecated = get(deprecatedDTFAddressesAtom)
 
   if (!positions) return undefined
 
   return positions.filter((position) => {
     // Chain filter
     if (!chains.includes(position.chainId.toString())) {
+      return false
+    }
+
+    // Deprecated filter: hide positions that only govern deprecated DTFs
+    if (
+      position.dtfs.length > 0 &&
+      position.dtfs.every((dtf) => deprecated.has(dtf.address.toLowerCase()))
+    ) {
       return false
     }
 
@@ -82,12 +92,15 @@ export const filteredVoteLockPositionsAtom = atom((get) => {
 // Get unique DTFs from all positions for the dropdown options
 export const availableDtfsAtom = atom((get) => {
   const positions = get(voteLockPositionsAtom)
+  const deprecated = get(deprecatedDTFAddressesAtom)
   if (!positions) return []
 
   const dtfSet = new Set<string>()
   positions.forEach((position) => {
     position.dtfs.forEach((dtf) => {
-      dtfSet.add(dtf.symbol)
+      if (!deprecated.has(dtf.address.toLowerCase())) {
+        dtfSet.add(dtf.symbol)
+      }
     })
   })
 

--- a/src/views/earn/views/yield-dtf/atoms.ts
+++ b/src/views/earn/views/yield-dtf/atoms.ts
@@ -1,5 +1,6 @@
 import { ListedToken } from '@/hooks/useTokenList'
 import { ChainId } from '@/utils/chains'
+import { deprecatedDTFAddressesAtom } from '@/views/earn/atoms'
 import { atom } from 'jotai'
 
 export const yieldDTFListAtom = atom<ListedToken[] | undefined>(undefined)
@@ -17,12 +18,18 @@ export const filteredYieldDTFListAtom = atom((get) => {
   const search = get(searchFilterAtom).toLowerCase()
   const chains = get(chainsFilterAtom)
   const selectedDtfs = get(dtfsFilterAtom)
+  const deprecated = get(deprecatedDTFAddressesAtom)
 
   if (!positions) return undefined
 
   return positions.filter((position) => {
     // Always filter out Arbitrum DTFs even if not in chain filter
     if (position.chain === ChainId.Arbitrum) {
+      return false
+    }
+
+    // Deprecated filter
+    if (deprecated.has(position.id.toLowerCase())) {
       return false
     }
 
@@ -51,12 +58,16 @@ export const filteredYieldDTFListAtom = atom((get) => {
 // Get unique DTFs from all positions for the dropdown options
 export const availableDtfsAtom = atom((get) => {
   const positions = get(yieldDTFListAtom)
+  const deprecated = get(deprecatedDTFAddressesAtom)
   if (!positions) return []
 
   const dtfSet = new Set<string>()
   positions
-    // Filter out Arbitrum DTFs from available options
-    .filter(position => position.chain !== ChainId.Arbitrum)
+    .filter(
+      (position) =>
+        position.chain !== ChainId.Arbitrum &&
+        !deprecated.has(position.id.toLowerCase())
+    )
     .forEach((position) => {
       dtfSet.add(position.symbol)
     })


### PR DESCRIPTION
## Summary
- Hide deprecated DTFs from the three /earn tabs — Index DTF Governance, Yield DTF Staking, and DeFi Yield — matching the existing behavior of the Discover table and Yield DTF cards.
- Reuses `useDeprecatedAddresses()` at the consumer component level (same pattern as `src/views/discover/components/yield/components/yield-dtf-list.tsx`).

## Filter rules
- Yield DTF Staking: drop entries whose `id` is in the deprecated set.
- Index DTF Governance: drop vote-lock positions whose governed DTFs are all deprecated.
- DeFi Yield (table + featured): drop pools whose underlying tokens include a deprecated DTF.