### PR TITLE
feat: enable mainnet for permissionless index dtf deploy

### DIFF
--- a/src/views/index-dtf/deploy/permissionless-defaults.ts
+++ b/src/views/index-dtf/deploy/permissionless-defaults.ts
@@ -4,7 +4,7 @@ import { DeployInputs, DeployStepId } from './form-fields'
 
 // Fixed vote-lock DAO addresses per chain for permissionless deploys
 export const PERMISSIONLESS_VOTE_LOCK: Record<number, Address> = {
-  [ChainId.Mainnet]: zeroAddress, // TODO: Real address needed
+  [ChainId.Mainnet]: '0x39Ee5CECDf6f151359DA1AC9FA4A32d4c765951e',
   [ChainId.Base]: '0xeDAB3789D7D2283214d8F65A6E412B00b1cBfB7a',
   [ChainId.BSC]: zeroAddress, // TODO: Real address needed
 }
@@ -19,7 +19,15 @@ export const PERMISSIONLESS_READONLY_STEPS = new Set<DeployStepId>([
 ])
 
 export const TRUSTED_ADDRESSES: Record<number, string[]> = {
-  [ChainId.Mainnet]: [],
+  [ChainId.Mainnet]: [
+    '0xF2d98377d80DADf725bFb97E91357F1d81384De2',
+    '0x1f4b58851cE2F1b2FF906042D32287A0FDF1B899',
+    '0x2dc04Aeae96e2f2b642b066e981e80Fe57abb5b2',
+    '0x8e0507C16435Caca6CB71a7Fb0e0636fd3891df4',
+    '0x03d03A026E71979BE3b08D44B01eAe4C5FF9da99',
+    '0x7f7bf1d0B4bb7395bb68E99e20C732f3AEFFfe47',
+    '0x7DaAf7Bc2eE8bf4C0ac7f37E6b6cfaEB3ed9a868',
+  ],
   [ChainId.Base]: [
     '0xF2d98377d80DADf725bFb97E91357F1d81384De2',
     '0x1f4b58851cE2F1b2FF906042D32287A0FDF1B899',

--- a/src/views/index-dtf/deploy/steps/metadata/chain-selector.tsx
+++ b/src/views/index-dtf/deploy/steps/metadata/chain-selector.tsx
@@ -55,7 +55,9 @@ const ChainSelector = () => {
   const readonlySteps = useAtomValue(readonlyStepsAtom)
   const chains =
     readonlySteps.size > 0
-      ? SUPPORTED_CHAINS.filter((c) => c === ChainId.Base)
+      ? SUPPORTED_CHAINS.filter(
+          (c) => c === ChainId.Base || c === ChainId.Mainnet
+        )
       : SUPPORTED_CHAINS
 
   const handleChainChange = (newChain: AvailableChain) => {


### PR DESCRIPTION
Adds Ethereum mainnet as a chain option for the permissionless Index DTF deploy flow (`/deploy-index`).

## Changes

- Set the Mainnet vote-lock DAO address in `PERMISSIONLESS_VOTE_LOCK` to `0x39Ee5CECDf6f151359DA1AC9FA4A32d4c765951e`.
- Mirror Base's `TRUSTED_ADDRESSES` list onto Mainnet so guardians / auction launchers prefill correctly.
- Widen the permissionless chain filter in `chain-selector.tsx` to allow both Base and Mainnet (BSC still intentionally hidden — vote-lock is still a placeholder there).

Factory deployers, governance deployer, and platform fees already had Mainnet entries, so no other config was touched.