### PR TITLE
Fix missing Edit page button for brand managers on BTC+ overview

### DIFF
--- a/src/views/index-dtf/overview/components/yield-index/yield-index-about.tsx
+++ b/src/views/index-dtf/overview/components/yield-index/yield-index-about.tsx
@@ -1,13 +1,22 @@
 import { Skeleton } from '@/components/ui/skeleton'
-import { indexDTFAtom, indexDTFBrandAtom } from '@/state/dtf/atoms'
+import {
+  indexDTFAtom,
+  indexDTFBrandAtom,
+  isBrandManagerAtom,
+} from '@/state/dtf/atoms'
 import { useAtomValue } from 'jotai'
 import SectionAnchor from '@/components/section-anchor'
 import { Link } from 'react-router-dom'
 import { ROUTES } from '@/utils/constants'
+import { Button } from '@/components/ui/button'
+import { ImagePlus } from 'lucide-react'
+import { useTrackIndexDTFClick } from '../../../hooks/useTrackIndexDTFPage'
 
 const YieldIndexAbout = () => {
   const data = useAtomValue(indexDTFAtom)
   const brandData = useAtomValue(indexDTFBrandAtom)
+  const isBrandManager = useAtomValue(isBrandManagerAtom)
+  const { trackClick } = useTrackIndexDTFClick('overview', 'overview')
 
   if (!data || !brandData) {
     return (
@@ -19,6 +28,19 @@ const YieldIndexAbout = () => {
 
   return (
     <div className="p-4 sm:p-6">
+      {isBrandManager && (
+        <div className="flex justify-end mb-4">
+          <Link
+            to={`../${ROUTES.MANAGE}`}
+            onClick={() => trackClick('brand_manager')}
+          >
+            <Button variant="outline" size="sm" className="gap-1 rounded-full">
+              <ImagePlus size={14} />
+              Edit page
+            </Button>
+          </Link>
+        </div>
+      )}
       <div className="flex items-center gap-1">
         <h2 className="text-2xl font-light mb-1">
           About {data.token.symbol}

--- a/src/views/index-dtf/overview/components/yield-index/yield-index-about.tsx
+++ b/src/views/index-dtf/overview/components/yield-index/yield-index-about.tsx
@@ -28,24 +28,27 @@ const YieldIndexAbout = () => {
 
   return (
     <div className="p-4 sm:p-6">
-      {isBrandManager && (
-        <div className="flex justify-end mb-4">
-          <Link
-            to={`../${ROUTES.MANAGE}`}
-            onClick={() => trackClick('brand_manager')}
-          >
-            <Button variant="outline" size="sm" className="gap-1 rounded-full">
-              <ImagePlus size={14} />
-              Edit page
-            </Button>
-          </Link>
-        </div>
-      )}
-      <div className="flex items-center gap-1">
+      <div className="mb-4 flex items-center gap-2">
         <h2 className="text-2xl font-light mb-1">
           About {data.token.symbol}
         </h2>
         <SectionAnchor id="about" />
+        {isBrandManager && (
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="ml-auto gap-1 rounded-full"
+          >
+            <Link
+              to={`../${ROUTES.MANAGE}`}
+              onClick={() => trackClick('brand_manager')}
+            >
+              <ImagePlus size={14} />
+              Edit page
+            </Link>
+          </Button>
+        )}
       </div>
       <p className="text-legend mb-4">
         {brandData.dtf?.description || data.mandate}


### PR DESCRIPTION
### Motivation
- BTC+ and similar yield-style DTFs render a different overview component that lacked the brand-manager gated "Edit page" CTA, so brand managers could not access the manage flow from that overview.
- The intent is to match the standard index overview behavior and surface the manage CTA only to wallets with the brand manager role.

### Description
- Updated `src/views/index-dtf/overview/components/yield-index/yield-index-about.tsx` to add the missing brand-manager gated Edit page CTA.
- Imported and used `isBrandManagerAtom`, `Button`, `ImagePlus`, and `useTrackIndexDTFClick`, and wired `useAtomValue(isBrandManagerAtom)` plus `trackClick('brand_manager')` for analytics.
- The CTA navigates to `../manage` and is conditionally rendered only when `isBrandManager` is true so non-brand-manager wallets remain unaffected.

### Testing
- Ran `pnpm run typecheck` (i.e., `tsc --noEmit`) and it completed successfully.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21af6fe88832489b2dca76d79712a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brand managers now see an outlined "Edit page" button on the yield index overview to manage page content.

* **UI Improvements**
  * Header layout on the overview page has been refined for better spacing and alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->