### PR TITLE
Allow two decimal places in revenue split inputs

### DIFF
--- a/src/components/rtoken-setup/token/ExternalRevenueSplit.tsx
+++ b/src/components/rtoken-setup/token/ExternalRevenueSplit.tsx
@@ -15,7 +15,7 @@ interface ExternalRevenueSplitProps {
 
 const inputValidation = {
   required: true,
-  pattern: /^[0-9]*[.]?[0-9]$/i,
+  pattern: /^[0-9]*[.]?[0-9]{0,2}$/i,
   min: 0,
   max: 100,
 }
@@ -55,7 +55,7 @@ const ExternalRevenueSpit = ({
       +stakers >= 0 &&
       +stakers <= 100
     ) {
-      setValue('holders', ((1000 - +stakers * 10) / 10).toString())
+      setValue('holders', ((10000 - +stakers * 100) / 100).toString())
     }
   }, [formValues[1]])
 
@@ -70,7 +70,7 @@ const ExternalRevenueSpit = ({
       +holders >= 0 &&
       +holders <= 100
     ) {
-      setValue('stakers', ((1000 - +holders * 10) / 10).toString())
+      setValue('stakers', ((10000 - +holders * 100) / 100).toString())
     }
   }, [formValues[2]])
 

--- a/src/components/rtoken-setup/token/ExternalRevenueSplit.tsx
+++ b/src/components/rtoken-setup/token/ExternalRevenueSplit.tsx
@@ -15,9 +15,13 @@ interface ExternalRevenueSplitProps {
 
 const inputValidation = {
   required: true,
-  pattern: /^[0-9]*[.]?[0-9]{0,2}$/i,
+  pattern: /^\d+(\.\d{1,2})?$/,
   min: 0,
   max: 100,
+}
+
+const getComplementarySplit = (value: string) => {
+  return (100 - Number(value)).toFixed(2).replace(/\.00$/, '')
 }
 
 const ExternalRevenueSpit = ({
@@ -55,7 +59,7 @@ const ExternalRevenueSpit = ({
       +stakers >= 0 &&
       +stakers <= 100
     ) {
-      setValue('holders', ((10000 - +stakers * 100) / 100).toString())
+      setValue('holders', getComplementarySplit(stakers))
     }
   }, [formValues[1]])
 
@@ -70,7 +74,7 @@ const ExternalRevenueSpit = ({
       +holders >= 0 &&
       +holders <= 100
     ) {
-      setValue('stakers', ((10000 - +holders * 100) / 100).toString())
+      setValue('stakers', getComplementarySplit(holders))
     }
   }, [formValues[2]])
 

--- a/src/components/rtoken-setup/token/RevenueSplit.tsx
+++ b/src/components/rtoken-setup/token/RevenueSplit.tsx
@@ -34,7 +34,7 @@ const updateExternalShareAtom = atom(
 
 const inputValidation = {
   required: true,
-  pattern: /^[0-9]*[.]?[0-9]$/i,
+  pattern: /^[0-9]*[.]?[0-9]{0,2}$/i,
   min: 0,
   max: 100,
 }

--- a/src/components/rtoken-setup/token/RevenueSplit.tsx
+++ b/src/components/rtoken-setup/token/RevenueSplit.tsx
@@ -34,7 +34,7 @@ const updateExternalShareAtom = atom(
 
 const inputValidation = {
   required: true,
-  pattern: /^[0-9]*[.]?[0-9]{0,2}$/i,
+  pattern: /^\d+(\.\d{1,2})?$/,
   min: 0,
   max: 100,
 }


### PR DESCRIPTION
### Motivation
- Users reported "Invalid number" validation errors when entering revenue split values with two decimal places (e.g. `45.23`) even though proposal simulation accepted them. 
- The UI limited inputs to a single decimal digit and auto-balancing math assumed 1-decimal precision, causing inconsistent validation and UX.

### Description
- Relaxed the form validation regex in `src/components/rtoken-setup/token/RevenueSplit.tsx` to allow up to two decimal places (`/^[0-9]*[.]?[0-9]{0,2}$/i`).
- Applied the same two-decimal validation to external-address splits in `src/components/rtoken-setup/token/ExternalRevenueSplit.tsx`.
- Adjusted the external split auto-balance math to preserve two-decimal precision by switching calculations from `((1000 - x*10)/10)` to `((10000 - x*100)/100)` so complementary fields match 2dp values.

### Testing
- Ran `pnpm -s typecheck`, which completed successfully.
- Attempted `pnpm -s eslint src/components/rtoken-setup/token/RevenueSplit.tsx src/components/rtoken-setup/token/ExternalRevenueSplit.tsx`, but ESLint could not run in this environment due to the repository not exposing an `eslint.config.(js|mjs|cjs)` file (ESLint v9 migration requirement), so linting was not executed here.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f260b8b18c8324b6945c1f5c65f7b3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved percentage input validation to allow up to two decimal places.
  * Reworked reciprocal percentage auto-calculation to derive the complementary value, format to two decimals, and trim unnecessary trailing ".00", ensuring the two fields remain mathematically consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->