### PR TITLE
fix: correct mainnet permissionless vote-lock address

### DIFF
--- a/src/views/index-dtf/deploy/permissionless-defaults.ts
+++ b/src/views/index-dtf/deploy/permissionless-defaults.ts
@@ -4,7 +4,7 @@ import { DeployInputs, DeployStepId } from './form-fields'
 
 // Fixed vote-lock DAO addresses per chain for permissionless deploys
 export const PERMISSIONLESS_VOTE_LOCK: Record<number, Address> = {
-  [ChainId.Mainnet]: '0x39Ee5CECDf6f151359DA1AC9FA4A32d4c765951e',
+  [ChainId.Mainnet]: '0xAFac0054FD8b3233c7b3b0E10E34188f6a7175f0',
   [ChainId.Base]: '0xeDAB3789D7D2283214d8F65A6E412B00b1cBfB7a',
   [ChainId.BSC]: zeroAddress, // TODO: Real address needed
 }


### PR DESCRIPTION
Updates the Mainnet vote-lock address used by the permissionless Index DTF deploy from `0x39Ee5CECDf6f151359DA1AC9FA4A32d4c765951e` (placeholder shipped in #984) to the correct deployed address `0xAFac0054FD8b3233c7b3b0E10E34188f6a7175f0`.

Single-file change in `src/views/index-dtf/deploy/permissionless-defaults.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mainnet deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->