### PR TITLE
chore: track contact modal view and click events

### DIFF
--- a/src/components/layout/contact-modal/contact-modal.tsx
+++ b/src/components/layout/contact-modal/contact-modal.tsx
@@ -8,24 +8,54 @@ import {
 import { Button } from '@/components/ui/button'
 import { Sparkles, X } from 'lucide-react'
 import { useAtom } from 'jotai'
+import mixpanel from 'mixpanel-browser/src/loaders/loader-module-core'
+import { useEffect } from 'react'
+import { Address } from 'viem'
 import { contactModalOpenAtom } from './atoms'
-import { useContactDismissal } from './use-contact-dismissal'
+import {
+  getContactDismissalKey,
+  useContactDismissal,
+} from './use-contact-dismissal'
 import { useContactCriteria } from './use-criteria'
 
 const CALENDLY_URL =
   'https://calendly.com/d/cycf-7kz-xjv/reserve-customer-discovery?from=slack'
+
+const isReopen = (wallet: Address | null) =>
+  !!wallet && localStorage.getItem(getContactDismissalKey(wallet)) === '1'
 
 const ContactModal = () => {
   const [open, setOpen] = useAtom(contactModalOpenAtom)
   const { wallet } = useContactCriteria()
   const { dismiss } = useContactDismissal(wallet)
 
+  useEffect(() => {
+    if (open) {
+      mixpanel.track('contact_us_modal_view', {
+        wallet,
+        is_reopen: isReopen(wallet),
+      })
+    }
+  }, [open, wallet])
+
   const handleOpenChange = (next: boolean) => {
-    if (!next) dismiss()
+    if (!next) {
+      mixpanel.track('contact_us_modal_click', {
+        action: 'dismissed',
+        wallet,
+        is_reopen: isReopen(wallet),
+      })
+      dismiss()
+    }
     setOpen(next)
   }
 
   const handleSchedule = () => {
+    mixpanel.track('contact_us_modal_click', {
+      action: 'scheduled',
+      wallet,
+      is_reopen: isReopen(wallet),
+    })
     dismiss()
     setOpen(false)
   }


### PR DESCRIPTION
## Summary

Adds Mixpanel tracking to the contact modal added in #982.

**Events:**
- `contact_us_modal_view` — fired when the modal opens (auto-open on criteria match or bell-button trigger)
- `contact_us_modal_click` — fired on close, with `action: 'scheduled' | 'dismissed'` to distinguish closing after clicking Calendly vs. closing via X / escape / outside click

**Properties on both events:**
- `wallet` — holder address
- `is_reopen` — `true` if the user previously dismissed and reopened via the bell, `false` on first auto-open (read from the dismissal localStorage flag before `dismiss()` runs)

Radix's `onOpenChange` only fires for user-initiated close, so the schedule path (which calls `setOpen(false)` programmatically) doesn't double-track.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined contact modal state management and interaction handling
  * Enhanced persistence for reopened modal interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reserve-protocol/register/pull/989)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->