### PR TITLE
Add USDi token logo mapping

### DIFF
--- a/src/components/token-logo/token-logo-mappings.ts
+++ b/src/components/token-logo/token-logo-mappings.ts
@@ -36,6 +36,7 @@ export const TOKEN_LOGO_MAPPINGS: Record<string, string> = {
   "uapt": "https://raw.githubusercontent.com/SmolDapp/tokenAssets/main/tokens/8453/0x9c0e042d65a2e1ff31ac83f404e5cb79f452c337/logo-128.png",
   "usei": "https://raw.githubusercontent.com/SmolDapp/tokenAssets/main/tokens/8453/0x71a67215a2025f501f386a49858a9ced2fc0249d/logo-128.png",
   "usui": "https://raw.githubusercontent.com/SmolDapp/tokenAssets/main/tokens/8453/0xb0505e5a99abd03d94a1169e638b78edfed26ea4/logo-128.png",
+  "usdi": "https://logo.svgcdn.com/token-branded/usdi.svg",
   "uatom": "https://token-icons.llamao.fi/icons/tokens/8453/0x6e934283dae5d5d1831cbe8d557c44c9b83f30ee",
   "uavax": "https://token-icons.llamao.fi/icons/tokens/8453/0xd6a34b430c05ac78c24985f8abee2616bc1788cb",
   "ubch": "https://raw.githubusercontent.com/SmolDapp/tokenAssets/main/tokens/8453/0x7be0cc2cadcd4a8f9901b4a66244dcdd9bd02e0f/logo-128.png",


### PR DESCRIPTION
### Motivation
- Ensure the USDi token displays the newly provided SVG icon in the Register UI by adding it to the token logo mapping.

### Description
- Added a `usdi` entry to `TOKEN_LOGO_MAPPINGS` in `src/components/token-logo/token-logo-mappings.ts` that points to `https://logo.svgcdn.com/token-branded/usdi.svg`.

### Testing
- No automated tests were run for this mapping-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b43f0c2c8324bfda1310fecc2f65)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying the USDI token logo throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reserve-protocol/register/pull/990)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->