### PR TITLE
fix: scale ondo leg sizes to matched auction size

### DIFF
--- a/src/views/index-dtf/auctions/views/rebalance/hooks/use-ondo-limit-status.ts
+++ b/src/views/index-dtf/auctions/views/rebalance/hooks/use-ondo-limit-status.ts
@@ -14,6 +14,7 @@ import {
   ExceededOndoLeg,
   getExceededOndoLegs,
   getMaxSafeRebalancePercent,
+  getScaledLegSizes,
   SizesByAddress,
 } from '../utils/get-max-safe-percent'
 import useRebalanceParams from './use-rebalance-params'
@@ -25,17 +26,6 @@ type OndoLimitStatus = {
   maxSafePercent: number
   // Open Ondo legs over their soft cap at the current percent.
   exceeded: ExceededOndoLeg[]
-}
-
-const legSizes = (metrics: AuctionMetrics): SizesByAddress => {
-  const sizes: SizesByAddress = {}
-  metrics.surplusTokens.forEach((token, i) => {
-    sizes[token.toLowerCase()] = metrics.surplusTokenSizes[i]
-  })
-  metrics.deficitTokens.forEach((token, i) => {
-    sizes[token.toLowerCase()] = metrics.deficitTokenSizes[i]
-  })
-  return sizes
 }
 
 const useOndoLimitStatus = (): OndoLimitStatus => {
@@ -57,7 +47,7 @@ const useOndoLimitStatus = (): OndoLimitStatus => {
         ? savedWeights
         : params.initialWeights
 
-    const computeSizes = (percent: number): SizesByAddress | null => {
+    const computeMetrics = (percent: number): AuctionMetrics | null => {
       try {
         const [, m] = getRebalanceOpenAuction(
           params.folioVersion,
@@ -75,7 +65,7 @@ const useOndoLimitStatus = (): OndoLimitStatus => {
           percent,
           isHybridDTF
         )
-        return legSizes(m)
+        return m
       } catch (e) {
         // Expected at some probe percents for a broken rebalance (the metrics
         // updater surfaces that); log so an unexpected failure is still visible.
@@ -84,7 +74,21 @@ const useOndoLimitStatus = (): OndoLimitStatus => {
       }
     }
 
-    return getMaxSafeRebalancePercent(computeSizes, ondoLimits)
+    const computeSizes = (percent: number): SizesByAddress | null => {
+      const m = computeMetrics(percent)
+      return m && getScaledLegSizes(m)
+    }
+
+    // At or below relativeProgression + 1 the SDK flips to a FINAL round that
+    // trades everything — keep the cap out of that zone (same +2 margin the
+    // dev slider guard uses). Progression doesn't depend on the percent, so
+    // probing at 100 is fine.
+    const probe = computeMetrics(100)
+    const minPercent = probe
+      ? Math.min(100, Math.ceil(probe.relativeProgression * 100) + 2)
+      : undefined
+
+    return getMaxSafeRebalancePercent(computeSizes, ondoLimits, minPercent)
   }, [
     params,
     currentRebalance,
@@ -97,7 +101,7 @@ const useOndoLimitStatus = (): OndoLimitStatus => {
 
   const exceeded = useMemo(() => {
     if (!metrics || Object.keys(ondoLimits).length === 0) return []
-    return getExceededOndoLegs(legSizes(metrics), ondoLimits)
+    return getExceededOndoLegs(getScaledLegSizes(metrics), ondoLimits)
   }, [metrics, ondoLimits])
 
   return { maxSafePercent, exceeded }

--- a/src/views/index-dtf/auctions/views/rebalance/tests/get-max-safe-percent.test.ts
+++ b/src/views/index-dtf/auctions/views/rebalance/tests/get-max-safe-percent.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect } from 'vitest'
+import { AuctionMetrics } from '@reserve-protocol/dtf-rebalance-lib'
 import {
   getExceededOndoLegs,
   getMaxSafeRebalancePercent,
+  getScaledLegSizes,
   ONDO_LIMIT_BUFFER,
   OndoLimit,
 } from '../utils/get-max-safe-percent'
 
 const A = '0xaaa'
 const B = '0xbbb'
+const C = '0xccc'
 
 // Linear model: at 100% each leg is $1M, scaling down with the percent — close
 // enough to the real monotonic SDK sizing to exercise the search.
@@ -65,6 +68,65 @@ describe('getMaxSafeRebalancePercent', () => {
     // Null above 50% forces the search below it; A still binds at ~19%.
     const sizes = (percent: number) => (percent > 50 ? null : linearSizes(percent))
     expect(getMaxSafeRebalancePercent(sizes, limits)).toBe(19)
+  })
+
+  it('never searches below minPercent (SDK full-trade zone)', () => {
+    // Below 31% (relativeProgression ~30%) the SDK would do the full trade —
+    // sizes there are the max, not small. The search must stay above it.
+    const sizes = (percent: number) =>
+      percent <= 31 ? linearSizes(100) : linearSizes(percent)
+    const limits: Record<string, OndoLimit> = {
+      [A]: { capacityUsd: 500_000, tradingOpen: true },
+    }
+    // Cap = $475k -> 47%; reachable only if the search isn't poisoned by the
+    // full-trade sizes at low percents.
+    expect(getMaxSafeRebalancePercent(sizes, limits, 32)).toBe(47)
+  })
+
+  it('falls back to minPercent when nothing fits', () => {
+    const limits: Record<string, OndoLimit> = {
+      [A]: { capacityUsd: 100, tradingOpen: true },
+    }
+    expect(getMaxSafeRebalancePercent(linearSizes, limits, 32)).toBe(32)
+  })
+})
+
+describe('getScaledLegSizes', () => {
+  const metrics = (
+    surplus: Record<string, number>,
+    deficit: Record<string, number>
+  ): AuctionMetrics =>
+    ({
+      surplusTokens: Object.keys(surplus),
+      surplusTokenSizes: Object.values(surplus),
+      deficitTokens: Object.keys(deficit),
+      deficitTokenSizes: Object.values(deficit),
+    }) as AuctionMetrics
+
+  it('scales eject surpluses (full position) down to the deficit side', () => {
+    // Ejected tokens report their whole position as surplus at any percent;
+    // only min(surplus, deficit) actually trades.
+    const sizes = getScaledLegSizes(
+      metrics({ [A]: 300_000, [B]: 100_000 }, { [C]: 200_000 })
+    )
+    expect(sizes[A]).toBeCloseTo(150_000)
+    expect(sizes[B]).toBeCloseTo(50_000)
+    expect(sizes[C]).toBeCloseTo(200_000)
+  })
+
+  it('scales the deficit side when the surplus side is smaller', () => {
+    const sizes = getScaledLegSizes(
+      metrics({ [A]: 100_000 }, { [B]: 150_000, [C]: 50_000 })
+    )
+    expect(sizes[A]).toBeCloseTo(100_000)
+    expect(sizes[B]).toBeCloseTo(75_000)
+    expect(sizes[C]).toBeCloseTo(25_000)
+  })
+
+  it('leaves balanced sides untouched', () => {
+    const sizes = getScaledLegSizes(metrics({ [A]: 100_000 }, { [B]: 100_000 }))
+    expect(sizes[A]).toBeCloseTo(100_000)
+    expect(sizes[B]).toBeCloseTo(100_000)
   })
 })
 

--- a/src/views/index-dtf/auctions/views/rebalance/utils/get-max-safe-percent.ts
+++ b/src/views/index-dtf/auctions/views/rebalance/utils/get-max-safe-percent.ts
@@ -1,3 +1,5 @@
+import { AuctionMetrics } from '@reserve-protocol/dtf-rebalance-lib'
+
 // Ondo tokenized equities cap the size of a single trade per account/session.
 // The rebalance percent drives each token's auction leg size, so we find the
 // highest percent at which every (open) Ondo leg stays within its session cap,
@@ -14,11 +16,37 @@ export type OndoLimit = {
 
 export type SizesByAddress = Record<string, number>
 
+// An auction only trades min(surplus, deficit) — the larger side reports the
+// full available amount (an ejected token's surplus is its whole position at
+// any percent), so scale each side to the matched auction size to get the USD
+// actually traded per token. Mirrors getAllTokensWithSizes in the liquidity
+// checker.
+export const getScaledLegSizes = (metrics: AuctionMetrics): SizesByAddress => {
+  const surplusTotal = metrics.surplusTokenSizes.reduce((a, b) => a + b, 0)
+  const deficitTotal = metrics.deficitTokenSizes.reduce((a, b) => a + b, 0)
+  const auctionSize = Math.min(surplusTotal, deficitTotal)
+  const sScale = surplusTotal > 0 ? auctionSize / surplusTotal : 0
+  const dScale = deficitTotal > 0 ? auctionSize / deficitTotal : 0
+
+  const sizes: SizesByAddress = {}
+  metrics.surplusTokens.forEach((token, i) => {
+    sizes[token.toLowerCase()] = metrics.surplusTokenSizes[i] * sScale
+  })
+  metrics.deficitTokens.forEach((token, i) => {
+    sizes[token.toLowerCase()] = metrics.deficitTokenSizes[i] * dScale
+  })
+  return sizes
+}
+
 // `computeSizes(percent)` returns the USD leg size per token address (lowercase)
 // for an auction launched at that percent, or null if the SDK can't price it.
+// `minPercent` bounds the search from below: at or under the current relative
+// progression (+1) the SDK flips to a FINAL round that trades everything, so
+// callers must keep the search above that zone.
 export const getMaxSafeRebalancePercent = (
   computeSizes: (percent: number) => SizesByAddress | null,
-  ondoLimits: Record<string, OndoLimit>
+  ondoLimits: Record<string, OndoLimit>,
+  minPercent = MIN_PERCENT
 ): number => {
   // Halted assets are skipped — we can't size against a closed market, and the
   // scope is "warn, don't cap" for those.
@@ -38,12 +66,12 @@ export const getMaxSafeRebalancePercent = (
 
   if (fits(100)) return 100
 
-  // Leg size is monotonic in percent, so binary-search the highest integer
-  // percent that fits. If none fits (an asset is over its cap even at the
-  // minimum), best stays at MIN_PERCENT — the slider still allows it.
-  let lo = MIN_PERCENT
+  // Above minPercent leg size is monotonic in percent, so binary-search the
+  // highest integer percent that fits. If none fits (an asset is over its cap
+  // even at the minimum), best stays at minPercent — the cap is soft.
+  let lo = minPercent
   let hi = 100
-  let best = MIN_PERCENT
+  let best = minPercent
   while (lo <= hi) {
     const mid = Math.floor((lo + hi) / 2)
     if (fits(mid)) {


### PR DESCRIPTION
Ejected tokens report their full position as surplus at any percent, so the Ondo cap search never fit and fell back to 1% - a degenerate value where the SDK flips to a FINAL round and trades everything. Scale both sides to min(surplus, deficit) like the liquidity checker, and keep the search above the SDK's full-trade zone (relativeProgression + 2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Ondo limit calculations for rebalancing operations to use scaled leg sizing with enhanced metric computation.

* **Tests**
  * Expanded test coverage for rebalance limit calculations and leg size scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->