### PR TITLE
fix: size ondo legs at min(leg, full deficit) instead of proportional split

### DIFF
--- a/src/views/index-dtf/auctions/views/rebalance/tests/get-max-safe-percent.test.ts
+++ b/src/views/index-dtf/auctions/views/rebalance/tests/get-max-safe-percent.test.ts
@@ -103,24 +103,25 @@ describe('getScaledLegSizes', () => {
       deficitTokenSizes: Object.values(deficit),
     }) as AuctionMetrics
 
-  it('scales eject surpluses (full position) down to the deficit side', () => {
-    // Ejected tokens report their whole position as surplus at any percent;
-    // only min(surplus, deficit) actually trades.
+  it('sizes each surplus leg at min(leg, full deficit) — the deficit is not split', () => {
+    // getBid offers every leg the entire remaining deficit, so a single trade
+    // can be as large as min(legSurplus, deficitTotal). A 3-leg ejection into
+    // one cash deficit must NOT report deficit/3 per leg.
     const sizes = getScaledLegSizes(
       metrics({ [A]: 300_000, [B]: 100_000 }, { [C]: 200_000 })
     )
-    expect(sizes[A]).toBeCloseTo(150_000)
-    expect(sizes[B]).toBeCloseTo(50_000)
+    expect(sizes[A]).toBeCloseTo(200_000)
+    expect(sizes[B]).toBeCloseTo(100_000)
     expect(sizes[C]).toBeCloseTo(200_000)
   })
 
-  it('scales the deficit side when the surplus side is smaller', () => {
+  it('sizes each deficit leg at min(leg, full surplus)', () => {
     const sizes = getScaledLegSizes(
       metrics({ [A]: 100_000 }, { [B]: 150_000, [C]: 50_000 })
     )
     expect(sizes[A]).toBeCloseTo(100_000)
-    expect(sizes[B]).toBeCloseTo(75_000)
-    expect(sizes[C]).toBeCloseTo(25_000)
+    expect(sizes[B]).toBeCloseTo(100_000)
+    expect(sizes[C]).toBeCloseTo(50_000)
   })
 
   it('leaves balanced sides untouched', () => {

--- a/src/views/index-dtf/auctions/views/rebalance/utils/get-max-safe-percent.ts
+++ b/src/views/index-dtf/auctions/views/rebalance/utils/get-max-safe-percent.ts
@@ -16,24 +16,29 @@ export type OndoLimit = {
 
 export type SizesByAddress = Record<string, number>
 
-// An auction only trades min(surplus, deficit) — the larger side reports the
-// full available amount (an ejected token's surplus is its whole position at
-// any percent), so scale each side to the matched auction size to get the USD
-// actually traded per token. Mirrors getAllTokensWithSizes in the liquidity
-// checker.
+// The deficit is NOT split across legs: getBid offers every surplus leg
+// min(legSurplus, remaining deficit), and the trusted-fillers bot sizes each
+// CoW order at exactly that — so a single trade can consume the entire
+// opposite side. Size each leg at that worst case; a proportional split
+// underestimates per-trade size by ~Nx with N concurrent legs and produces
+// orders over the Ondo cap (which the MM skips entirely, it never partial
+// fills).
 export const getScaledLegSizes = (metrics: AuctionMetrics): SizesByAddress => {
   const surplusTotal = metrics.surplusTokenSizes.reduce((a, b) => a + b, 0)
   const deficitTotal = metrics.deficitTokenSizes.reduce((a, b) => a + b, 0)
-  const auctionSize = Math.min(surplusTotal, deficitTotal)
-  const sScale = surplusTotal > 0 ? auctionSize / surplusTotal : 0
-  const dScale = deficitTotal > 0 ? auctionSize / deficitTotal : 0
 
   const sizes: SizesByAddress = {}
   metrics.surplusTokens.forEach((token, i) => {
-    sizes[token.toLowerCase()] = metrics.surplusTokenSizes[i] * sScale
+    sizes[token.toLowerCase()] = Math.min(
+      metrics.surplusTokenSizes[i],
+      deficitTotal
+    )
   })
   metrics.deficitTokens.forEach((token, i) => {
-    sizes[token.toLowerCase()] = metrics.deficitTokenSizes[i] * dScale
+    sizes[token.toLowerCase()] = Math.min(
+      metrics.deficitTokenSizes[i],
+      surplusTotal
+    )
   })
   return sizes
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated auction rebalancing leg sizing calculation to use a worst-case approach, where each leg accounts for the full opposite side rather than proportional scaling.

* **Tests**
  * Updated test assertions to reflect the new leg sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->