### PR TITLE
Fix manual mint max: leave headroom for the contract's ceil pull

### DIFF
--- a/src/views/index-dtf/issuance/manual/atoms.ts
+++ b/src/views/index-dtf/issuance/manual/atoms.ts
@@ -69,8 +69,12 @@ export const maxMintAmountAtom = atom((get) => {
     }
 
     const currentBalance = balanceMap[asset]
+    // The quote rate is floored (toAssets rounds down), but mint pulls collateral
+    // with Ceil rounding — dividing by the raw rate overshoots the max by a wei or
+    // two and reverts with "transfer amount exceeds balance". +1n on the divisor
+    // guarantees the ceil pull fits for every asset.
     const possibleAmount =
-      (currentBalance * parseEther('1')) / requiredAmountPerToken
+      (currentBalance * parseEther('1')) / (requiredAmountPerToken + 1n)
 
     if (maxAmount === undefined || possibleAmount < maxAmount) {
       maxAmount = possibleAmount

--- a/src/views/index-dtf/issuance/manual/tests/atoms.test.ts
+++ b/src/views/index-dtf/issuance/manual/tests/atoms.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { Provider, useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { Provider, useAtomValue, useSetAtom } from 'jotai'
 import { parseEther } from 'viem'
 import { createElement, ReactNode } from 'react'
 
@@ -10,7 +10,6 @@ import {
   balanceMapAtom,
   tokensNeedingApprovalAtom,
   allowanceMapAtom,
-  assetAmountsMapAtom,
   amountAtom,
 } from '../atoms'
 import { indexDTFAtom, indexDTFBasketAtom } from '@/state/dtf/atoms'
@@ -57,6 +56,17 @@ const createMockToken = (address: string) => ({
   name: 'Test Token',
   decimals: 18,
 })
+
+const E18 = parseEther('1')
+const ceilDiv = (a: bigint, b: bigint) => (a === 0n ? 0n : (a - 1n) / b + 1n)
+
+// The max intentionally sits a hair below the naive floor(balance / rate): the
+// quote rate is floored but the contract pulls with Ceil, so the max is divided
+// by (rate + 1) to guarantee the pull fits. The gap is negligible (~ideal/rate wei).
+const expectNearIdeal = (actual: bigint, ideal: bigint) => {
+  expect(actual).toBeLessThanOrEqual(ideal)
+  expect(ideal - actual).toBeLessThanOrEqual(ideal / 1_000_000n + 2n)
+}
 
 describe('maxMintAmountAtom', () => {
   describe('early returns (guard clauses)', () => {
@@ -139,7 +149,7 @@ describe('maxMintAmountAtom', () => {
         result.current.setBalanceMap({ '0xtoken': parseEther('100') })
       })
 
-      expect(result.current.maxMintAmount).toBe(parseEther('200'))
+      expectNearIdeal(result.current.maxMintAmount, parseEther('200'))
     })
 
     it('returns minimum across multiple assets (limiting asset)', () => {
@@ -163,7 +173,7 @@ describe('maxMintAmountAtom', () => {
         })
       })
 
-      expect(result.current.maxMintAmount).toBe(parseEther('150'))
+      expectNearIdeal(result.current.maxMintAmount, parseEther('150'))
     })
 
     it('skips assets with zero distribution (no division by zero)', () => {
@@ -183,7 +193,7 @@ describe('maxMintAmountAtom', () => {
       })
 
       // Should only consider tokenA: 100 / 0.5 = 200
-      expect(result.current.maxMintAmount).toBe(parseEther('200'))
+      expectNearIdeal(result.current.maxMintAmount, parseEther('200'))
     })
 
     it('handles very small balances correctly', () => {
@@ -197,7 +207,7 @@ describe('maxMintAmountAtom', () => {
         result.current.setBalanceMap({ '0xtoken': parseEther('0.001') })
       })
 
-      expect(result.current.maxMintAmount).toBe(parseEther('10'))
+      expectNearIdeal(result.current.maxMintAmount, parseEther('10'))
     })
 
     it('handles very large balances without overflow', () => {
@@ -212,7 +222,7 @@ describe('maxMintAmountAtom', () => {
         result.current.setBalanceMap({ '0xtoken': billion })
       })
 
-      expect(result.current.maxMintAmount).toBe(parseEther('1000000000'))
+      expectNearIdeal(result.current.maxMintAmount, parseEther('1000000000'))
     })
   })
 
@@ -232,6 +242,33 @@ describe('maxMintAmountAtom', () => {
       // Result * 3 should not exceed 100 (verifies floor behavior)
       const requiredForResult = (maxMint * parseEther('3')) / parseEther('1')
       expect(requiredForResult).toBeLessThanOrEqual(parseEther('100'))
+    })
+
+    // Regression: "ERC20: transfer amount exceeds balance" on max mint.
+    // The quote rate is floor(folioBalance * 1e18 / totalSupply), but the contract
+    // pulls collateral with Ceil at full folioBalance/totalSupply precision. Dividing
+    // the wallet balance by the raw floored rate overshoots the true max, and the
+    // contract's Ceil pull then exceeds the wallet balance by a wei or two. Modeled
+    // here via B/S so the floored rate has a large fractional part (the overshoot case);
+    // the max must leave room for the real ceil pull. Old code (divide by rate) fails.
+    it('leaves headroom for the contract ceil pull', () => {
+      const folioBalance = 2n
+      const totalSupply = 3n
+      const quoteRate = (folioBalance * E18) / totalSupply // floor -> 666…666
+      const walletBalance = parseEther('2')
+
+      const wrapper = createWrapper()
+      const { result } = renderHook(() => useTestSetup(), { wrapper })
+
+      act(() => {
+        result.current.setIndexDTF(createMockIndexDTF())
+        result.current.setAssetDistribution({ '0xtoken': quoteRate })
+        result.current.setBalanceMap({ '0xtoken': walletBalance })
+      })
+
+      const maxMint = result.current.maxMintAmount
+      const contractPull = ceilDiv(folioBalance * maxMint, totalSupply)
+      expect(contractPull).toBeLessThanOrEqual(walletBalance)
     })
   })
 })


### PR DESCRIPTION
## Problem

Minting the "Max" amount on the Index DTF manual mint reverted with `ERC20: transfer amount exceeds balance`. Users had to manually shave a few decimals off the max to get the transaction through.

## Cause

The per-share collateral quote comes from `toAssets(1e18, 0)` — rounding mode **Floor**, so the rate is rounded down. The max is then computed as `floor(walletBalance × 1e18 / rate)`. Because the divisor was floored (slightly too small), the resulting max is slightly too large.

The on-chain `mint(shares)` pulls collateral with `_toAssets(shares, Ceil)` — rounding **up**, at full `folioBalance / totalSupply` precision. On the binding asset the client's max left as little as 1 wei of headroom, which the contract's ceil rounding consumed, pushing the required pull 1–2 wei over the wallet balance and reverting.

## Fix

Divide the wallet balance by `rate + 1` instead of `rate` when computing the max. Since the floored rate `r` satisfies `r ≤ folioBalance × 1e18 / totalSupply < r + 1`, using `r + 1` guarantees the computed max stays at or below `walletBalance × totalSupply / folioBalance` — exactly the condition for the contract's ceil pull to fit, for every asset (we take the min across the basket). The cost is negligibly conservative (on the reported case it trims the max by ~1093 wei, the ~15th decimal).

## Tests

Added a regression test that models an asset via `folioBalance / totalSupply` so the floored quote rate has a large fractional part (the overshoot case). It asserts the contract's ceil pull at the computed max never exceeds the wallet balance — it fails on the old `/ rate` code and passes on `/ (rate + 1)`. Existing evenly-divisible cases relaxed from exact equality to "essentially the ideal, never above."

Verified end-to-end: the previously-reverting max mint now goes through.