### PR TITLE
docs: update DTF LLM docs to v0.6

### DIFF
--- a/public/dtf-llm/buildout-dtf.md
+++ b/public/dtf-llm/buildout-dtf.md
@@ -1,7 +1,8 @@
 ---
 title: "Reserve AI Infrastructure DTF ($BUILDOUT) — Complete Reference"
-version: "0.5"
-version_date: "2026-06-22"
+version: "0.6"
+version_date: "2026-07-08"
+launch_date: "2026-07-09"
 ticker: BUILDOUT
 product_type: "Index DTF (Decentralized Token Fund)"
 theme: "AI infrastructure — the picks & shovels of the AI buildout: semiconductors, memory, manufacturing equipment, networking, and power"
@@ -33,7 +34,7 @@ not_advice: "For informational purposes only. Not investment, legal, or tax advi
 
 # Reserve AI Infrastructure DTF ($BUILDOUT) — The Complete Reference
 
-> **Version 0.5** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
+> **Version 0.6** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
 
 > **⚠️ This document was generated with the assistance of a large language model (LLM).** It is a reference compiled from Reserve's published materials (reserve.org, docs.reserve.org, app.reserve.org), the official BUILDOUT tear sheet, and publicly reported third-party information. It is **not** investment, legal, or tax advice; it is **not** an offer or solicitation; and it may contain errors, omissions, or out-of-date figures. All numbers are **illustrative and approximate as of June 2026** and change at every quarterly rebalance and with the market. Where this document and Reserve's official sources (app.reserve.org, docs.reserve.org, and reserve.org/terms_and_conditions) disagree, **the official sources control.** Always verify on app.reserve.org before acting. See the full legal disclaimer at the end.
 
@@ -101,7 +102,7 @@ The document is organized roughly from "what is this and why does it exist" → 
 | **Rebalance** | Quarterly |
 | **Aggregate constituent market cap** | ~$16.7T (illustrative, basket data as of June 17, 2026) |
 | **Fees** | **0.3% mint fee** + **0.6% annual TVL (management) fee**; a protocol platform fee is taken out of those fees and used to buy and burn RSR. Onchain gas, exchange spreads, and Ondo mint/redeem terms also apply |
-| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus partner venues on BSC (e.g., PancakeSwap) and aggregators (1inch, CoW Swap); onchain, no min/max |
+| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus **PancakeSwap** on BNB Chain via **PancakeSwap X** — its aggregated, gas-free, MEV-protected trade engine (on BNB Chain, PancakeSwap X handles real-world assets like these DTFs); onchain, no min/max |
 | **How you pay** | Pay with a range of supported crypto via the app's **zapper** — **BNB, WBNB, USDT**, and other supported tokens — or mint/redeem with the exact basket tokens. USDT is one option, not the only one. |
 | **Who can buy** | Set by Ondo Global Markets. **Prohibited:** US, Canada, sanctioned jurisdictions. **Restricted (accredited/professional only):** UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil. **Elsewhere:** connect a wallet and buy, subject to your own local laws |
 | **Operator** | Reserve.org and app.reserve.org are operated by **ABC Labs, LLC**, which is **not** a bank, broker-dealer, or investment adviser and is **not** registered with the SEC, CFTC, or any financial regulator |
@@ -546,6 +547,8 @@ The single takeaway: **a tokenized stock is not legally identical to owning the 
 
 The underlying US equities trade only during US market hours, but the tokenized stocks (and BUILDOUT) trade **24/7**. Overnight and weekend news can move the "fair" value of the underlying companies while the official stock price is frozen, so the token can trade at a premium or discount to the last equity close and then re-converge when US markets reopen. This is a structural feature of trading an equity-backed token around the clock, and a source of the NAV-deviation risk in Section 13.4.
 
+**Actions can be limited when US markets are closed.** Because the underlying tokenized stocks track US-listed equities, minting, redeeming, and trading can be **constrained, paused, or priced conservatively outside US market hours** (nights, weekends, and US holidays). Reserve's automated liquidity management (e.g., Steer) manages pool pricing during these closures, but you may see wider spreads, thinner depth, or a given DTF being temporarily unavailable to trade after hours — so it is often best to transact during US market hours.
+
 ### 9.6 Why not just hold the tokenized stocks individually?
 
 You could, in principle, hold the 25 underlying Ondo tokens directly rather than holding BUILDOUT. BUILDOUT's advantages over doing so are the same as any index wrapper: one transaction instead of 25, automatic capped market-cap weighting, automatic quarterly reconstitution, and a single position to manage — at the cost of the DTF's fees and an extra layer of smart-contract dependency. The choice is a convenience-vs-control trade-off.
@@ -570,7 +573,7 @@ This is the practical "how do I actually use it" section. **Always confirm the l
 4. Review the quote — the app's zapper (or, for BUILDOUT's Ondo-backed underlyings, the RFQ/intent route) converts your chosen token into the basket and mints BUILDOUT in one atomic transaction.
 5. Confirm the transaction in your wallet and pay gas. You now hold BUILDOUT.
 
-You can also buy/sell BUILDOUT on **partner venues** where it's available — **1inch, PancakeSwap, and CoW Swap** are named on the tear sheet — though availability and liquidity vary by venue and chain.
+You can also buy/sell BUILDOUT on **PancakeSwap** (BNB Chain) through **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with **gas-free, MEV-protected swaps**. On BNB Chain, PancakeSwap X supports **real-world assets (RWAs)** — exactly the category these DTFs fall into (docs.pancakeswap.finance/trade/pancakeswap-x). Availability and liquidity vary.
 
 ### 10.3 Selling
 
@@ -614,7 +617,7 @@ In short: **you can swap in and out of BUILDOUT with ordinary crypto — BNB, WB
 
 ### 10.9 Liquidity and market-making
 
-These DTFs are newly launched, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
+The suite launched on app.reserve.org on **July 9, 2026**, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
 
 ---
 
@@ -634,7 +637,7 @@ Three points that matter:
 - **Eligibility can change** as Ondo updates its rules, and verification requirements in "restricted" jurisdictions can involve a KYC/accreditation step.
 - **You are responsible for your local laws** even in "elsewhere" jurisdictions — tax, securities, and other regulations may still apply to you.
 
-**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
+**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. The app also applies **geographic access controls**: visitors from prohibited regions are shown a geo-block / eligibility modal and cannot proceed, and this platform-level geo-blocking is applied on Reserve's app (and, where implemented, on partner trading venues). Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
 
 - **Can I mint/redeem on app.reserve.org?** In a restricted jurisdiction, generally **not until you have been approved** as an accredited/professional investor (you can apply — see above). The authoritative check is **in the app**: connect your wallet and start the purchase flow and it will tell you directly whether you pass the eligibility gate.
 - **Can I just buy it on a DEX instead?** The DTF is an ERC-20 on BNB Chain, so in principle it can trade on DEXs (e.g., PancakeSwap) outside the app — **but this is not a reliable way around the eligibility rules.** The underlying Ondo tokenized stocks carry **transfer allowlists/permissioning** that can block the wrapper from moving to non-eligible wallets, and using secondary markets to circumvent the issuer's eligibility terms can conflict with **Ondo's terms** and your local rules. Don't treat it as a clean path.
@@ -693,7 +696,7 @@ The AI-infrastructure thesis could be wrong or already priced in (Section 3.5). 
 
 ### 13.4 Tracking / NAV-deviation risk
 
-BUILDOUT's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** BUILDOUT tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7, additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. These products are newly launched; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
+BUILDOUT's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** BUILDOUT tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7, additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. The suite launched in **July 2026**; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
 
 ### 13.5 Issuer and custodian risk (Ondo / tokenized stocks)
 
@@ -817,7 +820,8 @@ In the interest of the same candor Reserve applies to its own marketing, the mat
 - **AI accelerator** — a chip specialized for the matrix math of AI; includes GPUs (Nvidia, AMD) and custom ASICs/XPUs.
 - **ASIC / XPU** — an application-specific integrated circuit; custom AI silicon co-designed for a specific buyer (e.g., hyperscaler chips built with Broadcom or Marvell).
 - **Basket** — the set of underlying tokens a DTF holds; for BUILDOUT, 25 tokenized US-listed AI-hardware stocks.
-- **CoW Swap** — a decentralized-exchange / solver network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions; also a venue where BUILDOUT may trade.
+- **CoW Swap** — a solver/DEX network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions, sourcing deep liquidity for onchain rebalances.
+- **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with gas-free and MEV-protected swaps; it powers swaps on PancakeSwap, and on BNB Chain it supports real-world assets (RWAs) — the category these DTFs fall into. Docs: docs.pancakeswap.finance/trade/pancakeswap-x.
 - **CPU / IP** — the central processor and the licensed processor designs/architecture it is built on; Arm (ARM) is the basket's CPU-IP exposure.
 - **DTF (Decentralized Token Fund; formerly "Folio")** — a fully asset-backed ERC-20 token created with Reserve's contracts that represents a basket of underlying tokens; mint/redeemable and governed permissionlessly onchain. BUILDOUT is an **Index DTF**.
 - **Dutch auction** — the declining-price auction mechanism Reserve uses to rebalance DTF baskets onchain.
@@ -880,7 +884,7 @@ A: A **0.3% mint fee** and a **0.6% annual TVL (management) fee.** A protocol pl
 A: No minimum or maximum purchase size.
 
 **Q: How do I buy it?**
-A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on partner venues (PancakeSwap and other BNB Chain DEXs; aggregators like 1inch, CoW Swap). You must be in an eligible jurisdiction.
+A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on **PancakeSwap** (BNB Chain) via **PancakeSwap X** — gas-free and MEV-protected; on BNB Chain, PancakeSwap X supports real-world assets like these DTFs. You must be in an eligible jurisdiction.
 
 **Q: Can I buy it in the United States?**
 A: **No.** BUILDOUT is prohibited for US persons (and US territories, Canada, and sanctioned jurisdictions). Several other places (UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil) allow it only for accredited/professional investors. Eligibility is set by Ondo.
@@ -890,6 +894,9 @@ A: Ondo Global Markets, the issuer of the underlying tokenized stocks. See docs.
 
 **Q: I'm in a restricted jurisdiction (e.g., UK, EEA, Brazil) — how do I get approved?**
 A: You can apply. In restricted jurisdictions you submit a request to be verified as an accredited/professional investor (through the app) and complete the required verification; approvals are processed by Reserve, potentially with the help of a third-party accreditation provider.
+
+**Q: How can a "decentralized" token be restricted by country? Doesn't that require KYC, which would make it centralized?**
+A: This mixes up two layers. **(1) The token/protocol layer is decentralized:** BUILDOUT is a permissionless ERC-20 on BNB Chain — the contracts are open-source and governed onchain, anyone can mint or redeem at the value of the underlying, no central party can seize or freeze the token in your wallet, and you can always redeem onchain for the underlying assets without permission. **(2) The restriction lives one layer down, in what BUILDOUT holds:** Ondo Global Markets tokenized stocks, each backed 1:1 by a real share in a regulated US brokerage account. Because those are actual securities, their issuer (Ondo) applies eligibility rules and transfer permissioning to comply with securities law — so "not available in country X" is set by **Ondo, the issuer of the underlying**, not by Reserve and not because the DTF is "centralized." **And it is not enforced by KYC on the token:** the basic access gate on app.reserve.org is a **wallet self-attestation** (you tick boxes confirming eligibility), tied only to your wallet address and never your personal info — Reserve does not collect or store identity documents for it. Only if you are in a *restricted* jurisdiction and want to qualify as an accredited/professional investor is there an optional verification step. In short: **the DTF wrapper is decentralized; the real-world asset it wraps carries the compliance perimeter of the real security behind it.** That is the tradeoff of tokenizing regulated assets — a real share behind every token, and the issuer's eligibility rules riding along with it. (The flip side, disclosed in Section 13.5: because it wraps Ondo's tokenized stock, you take on Ondo as an issuer — decentralized at the protocol layer, but the real-world-asset layer is not trustless.)
 
 **Q: What gives BUILDOUT its value / how is it priced?**
 A: Its price is based on the **NAV** of its underlying tokenized stocks. Because anyone can mint/redeem at NAV onchain, arbitrage keeps the market price close to the value of the basket — though deviations can occur.
@@ -987,4 +994,4 @@ The third-party market-size forecasts referenced (WSTS and others) are estimates
 
 ---
 
-*Document type: LLM-generated reference for the Reserve AI Infrastructure DTF ($BUILDOUT). Document version 0.5 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and one of the Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, ROBOTS, PHOTON). Verify everything on app.reserve.org before acting.*
+*Document type: LLM-generated reference for the Reserve AI Infrastructure DTF ($BUILDOUT). Document version 0.6 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and one of the Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, ROBOTS, PHOTON). Verify everything on app.reserve.org before acting.*

--- a/public/dtf-llm/index.json
+++ b/public/dtf-llm/index.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.5",
+  "version": "0.6",
   "suite": "Reserve Thematic AI DTF Suite",
-  "generated": "2026-06-22",
+  "generated": "2026-07-08",
   "index": "https://app.reserve.org/dtf-llm/llms.txt",
   "disclaimer": "Auto-generated with LLM assistance, pending review. Not investment, legal, or tax advice and not an offer or solicitation. The DTFs are not ETFs and not regulated as such; they are concentrated, single-theme baskets of experimental tokenized assets that can lose value entirely, and are not available to US persons or persons in sanctioned jurisdictions. Where these documents disagree with Reserve's official sources, the official sources control. Verify everything on https://app.reserve.org.",
   "docs": [
@@ -13,7 +13,7 @@
       "chain": "BNB Smart Chain",
       "address": "0xa0fe4e0aeca5479705ce996615b2eacb6b6a10fb",
       "coingecko": "reserve-ai-photonics-dtf",
-      "bytes": 135510
+      "bytes": 138962
     },
     {
       "symbol": "BUILDOUT",
@@ -23,7 +23,7 @@
       "chain": "BNB Smart Chain",
       "address": "0xd7ce7a841310982acd976d1a6fe7bb6063c5689d",
       "coingecko": "reserve-ai-infrastructure-dtf",
-      "bytes": 146426
+      "bytes": 149880
     },
     {
       "symbol": "POWER",
@@ -33,7 +33,7 @@
       "chain": "BNB Smart Chain",
       "address": "0x290bCc0Fd5096cC3261AE2021841c7BC67Cb0f51",
       "coingecko": "reserve-ai-power-dtf",
-      "bytes": 150183
+      "bytes": 153634
     },
     {
       "symbol": "NEOCLOUD",
@@ -43,7 +43,7 @@
       "chain": "BNB Smart Chain",
       "address": "0xf571Fe3F0d74521Bc7310B111Faea931C748f27B",
       "coingecko": "reserve-ai-capacity-and-neocloud-dtf",
-      "bytes": 149000
+      "bytes": 152454
     },
     {
       "symbol": "ROBOTS",
@@ -53,7 +53,7 @@
       "chain": "BNB Smart Chain",
       "address": "0x75617e7653f86f074cc30b9fd4ebf52ba9b62247",
       "coingecko": "reserve-robotics-dtf",
-      "bytes": 146338
+      "bytes": 149790
     }
   ]
 }

--- a/public/dtf-llm/llms.txt
+++ b/public/dtf-llm/llms.txt
@@ -1,6 +1,6 @@
 # Reserve AI DTF Suite — LLM Reference Documents
 
-*Index version 0.5 — draft (auto-generated, pending review).*
+*Index version 0.6 — draft (auto-generated, pending review).*
 
 > **What this is.** This is an index of long-form, LLM-feedable reference documents for the **Reserve Thematic AI DTF Suite** — five onchain index tokens (Decentralized Token Funds) covering the AI build-out. Each linked document is self-contained and designed to be dropped into an AI assistant (Claude, ChatGPT, etc.) so it can answer essentially any question about that product: the thesis, every constituent, what a DTF is, how Reserve works, fees, eligibility, risks, and more.
 
@@ -18,7 +18,7 @@
 
 ## About the suite
 
-All five are **Index DTFs** built with Reserve's open-source Index Protocol and deployed on **BNB Smart Chain**. Each is a single ERC-20 token holding a market-cap-weighted basket of US-listed equities via **Ondo Global Markets tokenized stocks** (each backed 1:1 by a real share in a regulated US brokerage account), rebalanced **quarterly** via onchain Dutch auctions. Fees are **0.3% mint + 0.6% annual TVL** (plus a protocol platform fee used to buy and burn RSR). Buy/sell/redeem onchain at **https://app.reserve.org**, with no minimum or maximum. Eligibility is set by Ondo (not for US/Canada/sanctioned jurisdictions; accredited/professional-only in the UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, and Brazil).
+All five are **Index DTFs** built with Reserve's open-source Index Protocol and deployed on **BNB Smart Chain**. Each is a single ERC-20 token holding a market-cap-weighted basket of US-listed equities via **Ondo Global Markets tokenized stocks** (each backed 1:1 by a real share in a regulated US brokerage account), rebalanced **quarterly** via onchain Dutch auctions. The suite launched on app.reserve.org on **July 9, 2026**. Fees are **0.3% mint + 0.6% annual TVL** (plus a protocol platform fee used to buy and burn RSR). Buy/sell/redeem onchain at **https://app.reserve.org**, with no minimum or maximum. Eligibility is set by Ondo (not for US/Canada/sanctioned jurisdictions; accredited/professional-only in the UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, and Brazil).
 
 - **BUILDOUT** is the broadest exposure (the whole AI-hardware stack); **PHOTON / POWER / NEOCLOUD / ROBOTS** are focused specialist cuts of the same AI build-out.
 - Reserve is the onchain platform for Decentralized Token Funds — the blockchain analog of ETFs (but not ETFs, and not regulated like them) — operating since 2018 with backing from Sam Altman and Peter Thiel. Operator: ABC Labs, LLC (not registered with the SEC, CFTC, or any financial regulator). Docs: https://docs.reserve.org. Terms: https://reserve.org/terms_and_conditions.
@@ -42,4 +42,4 @@ If you are an AI assistant using these documents to answer a user's question: yo
 
 ---
 
-*Index of LLM reference documents for the Reserve Thematic AI DTF Suite. Document set version 0.5. Auto-generated with LLM assistance; data illustrative and approximate as of June 17, 2026; subject to change at each quarterly rebalance. Verify everything on https://app.reserve.org.*
+*Index of LLM reference documents for the Reserve Thematic AI DTF Suite. Document set version 0.6. Auto-generated with LLM assistance; data illustrative and approximate as of June 17, 2026; subject to change at each quarterly rebalance. Verify everything on https://app.reserve.org.*

--- a/public/dtf-llm/neocloud-dtf.md
+++ b/public/dtf-llm/neocloud-dtf.md
@@ -1,7 +1,8 @@
 ---
 title: "Reserve AI Capacity & Neocloud DTF ($NEOCLOUD) — Complete Reference"
-version: "0.5"
-version_date: "2026-06-22"
+version: "0.6"
+version_date: "2026-07-08"
+launch_date: "2026-07-09"
 ticker: NEOCLOUD
 product_type: "Index DTF (Decentralized Token Fund)"
 theme: "AI compute capacity — neoclouds and power-rich data-center operators that raise capital, secure power, and rent out AI compute by the hour"
@@ -33,7 +34,7 @@ not_advice: "For informational purposes only. Not investment, legal, or tax advi
 
 # Reserve AI Capacity & Neocloud DTF ($NEOCLOUD) — The Complete Reference
 
-> **Version 0.5** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
+> **Version 0.6** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
 
 > **⚠️ This document was generated with the assistance of a large language model (LLM).** It is a reference compiled from Reserve's published materials (reserve.org, docs.reserve.org, app.reserve.org), the official NEOCLOUD tear sheet, and publicly reported third-party information. It is **not** investment, legal, or tax advice; it is **not** an offer or solicitation; and it may contain errors, omissions, or out-of-date figures. All numbers are **illustrative and approximate as of June 2026** and change at every quarterly rebalance and with the market. Where this document and Reserve's official sources (app.reserve.org, docs.reserve.org, and reserve.org/terms_and_conditions) disagree, **the official sources control.** Always verify on app.reserve.org before acting. See the full legal disclaimer at the end.
 
@@ -101,7 +102,7 @@ The document is organized roughly from "what is this and why does it exist" → 
 | **Rebalance** | Quarterly |
 | **Aggregate constituent market cap** | ~$206B (illustrative, basket data as of June 17, 2026) |
 | **Fees** | **0.3% mint fee** + **0.6% annual TVL (management) fee**; a protocol platform fee is taken out of those fees and used to buy and burn RSR. Onchain gas, exchange spreads, and Ondo mint/redeem terms also apply |
-| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus partner venues on BSC (e.g., PancakeSwap) and aggregators (1inch, CoW Swap); onchain, no min/max |
+| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus **PancakeSwap** on BNB Chain via **PancakeSwap X** — its aggregated, gas-free, MEV-protected trade engine (on BNB Chain, PancakeSwap X handles real-world assets like these DTFs); onchain, no min/max |
 | **How you pay** | Pay with a range of supported crypto via the app's **zapper** — **BNB, WBNB, USDT**, and other supported tokens — or mint/redeem with the exact basket tokens. USDT is one option, not the only one. |
 | **Who can buy** | Set by Ondo Global Markets. **Prohibited:** US, Canada, sanctioned jurisdictions. **Restricted (accredited/professional only):** UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil. **Elsewhere:** connect a wallet and buy, subject to your own local laws |
 | **Operator** | Reserve.org and app.reserve.org are operated by **ABC Labs, LLC**, which is **not** a bank, broker-dealer, or investment adviser and is **not** registered with the SEC, CFTC, or any financial regulator |
@@ -560,6 +561,8 @@ The single takeaway: **a tokenized stock is not legally identical to owning the 
 
 The underlying US equities trade only during US market hours, but the tokenized stocks (and NEOCLOUD) trade **24/7**. Overnight and weekend news can move the "fair" value of the underlying companies while the official stock price is frozen, so the token can trade at a premium or discount to the last equity close and then re-converge when US markets reopen. This is a structural feature of trading an equity-backed token around the clock, and a source of the NAV-deviation risk in Section 13.4. (NEOCLOUD's constituents are notably volatile, news-sensitive stocks — large lease, financing, and customer announcements have repeatedly moved them sharply — so these gaps can be larger than for a basket of staid blue chips.)
 
+**Actions can be limited when US markets are closed.** Because the underlying tokenized stocks track US-listed equities, minting, redeeming, and trading can be **constrained, paused, or priced conservatively outside US market hours** (nights, weekends, and US holidays). Reserve's automated liquidity management (e.g., Steer) manages pool pricing during these closures, but you may see wider spreads, thinner depth, or a given DTF being temporarily unavailable to trade after hours — so it is often best to transact during US market hours.
+
 ### 9.6 Why not just hold the tokenized stocks individually?
 
 You could, in principle, hold the eight underlying Ondo tokens directly rather than holding NEOCLOUD. NEOCLOUD's advantages over doing so are the same as any index wrapper: one transaction instead of eight, automatic capped market-cap weighting, automatic quarterly reconstitution, and a single position to manage — at the cost of the DTF's fees and an extra layer of smart-contract dependency. The choice is a convenience-vs-control trade-off.
@@ -584,7 +587,7 @@ This is the practical "how do I actually use it" section. **Always confirm the l
 4. Review the quote — the app's zapper (or, for NEOCLOUD's Ondo-backed underlyings, the RFQ/intent route) converts your chosen token into the basket and mints NEOCLOUD in one atomic transaction.
 5. Confirm the transaction in your wallet and pay gas. You now hold NEOCLOUD.
 
-You can also buy/sell NEOCLOUD on **partner venues** where it's available — **1inch, PancakeSwap, and CoW Swap** are named on the tear sheet — though availability and liquidity vary by venue and chain.
+You can also buy/sell NEOCLOUD on **PancakeSwap** (BNB Chain) through **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with **gas-free, MEV-protected swaps**. On BNB Chain, PancakeSwap X supports **real-world assets (RWAs)** — exactly the category these DTFs fall into (docs.pancakeswap.finance/trade/pancakeswap-x). Availability and liquidity vary.
 
 ### 10.3 Selling
 
@@ -628,7 +631,7 @@ In short: **you can swap in and out of NEOCLOUD with ordinary crypto — BNB, WB
 
 ### 10.9 Liquidity and market-making
 
-These DTFs are newly launched, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
+The suite launched on app.reserve.org on **July 9, 2026**, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
 
 ---
 
@@ -648,7 +651,7 @@ Three points that matter:
 - **Eligibility can change** as Ondo updates its rules, and verification requirements in "restricted" jurisdictions can involve a KYC/accreditation step.
 - **You are responsible for your local laws** even in "elsewhere" jurisdictions — tax, securities, and other regulations may still apply to you.
 
-**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
+**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. The app also applies **geographic access controls**: visitors from prohibited regions are shown a geo-block / eligibility modal and cannot proceed, and this platform-level geo-blocking is applied on Reserve's app (and, where implemented, on partner trading venues). Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
 
 - **Can I mint/redeem on app.reserve.org?** In a restricted jurisdiction, generally **not until you have been approved** as an accredited/professional investor (you can apply — see above). The authoritative check is **in the app**: connect your wallet and start the purchase flow and it will tell you directly whether you pass the eligibility gate.
 - **Can I just buy it on a DEX instead?** The DTF is an ERC-20 on BNB Chain, so in principle it can trade on DEXs (e.g., PancakeSwap) outside the app — **but this is not a reliable way around the eligibility rules.** The underlying Ondo tokenized stocks carry **transfer allowlists/permissioning** that can block the wrapper from moving to non-eligible wallets, and using secondary markets to circumvent the issuer's eligibility terms can conflict with **Ondo's terms** and your local rules. Don't treat it as a clean path.
@@ -715,7 +718,7 @@ The neocloud thesis could be wrong or already priced in (Section 3.7), and the t
 
 ### 13.4 Tracking / NAV-deviation risk
 
-NEOCLOUD's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** NEOCLOUD tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7 — and because these are unusually volatile, news-sensitive stocks — additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. These products are newly launched; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
+NEOCLOUD's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** NEOCLOUD tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7 — and because these are unusually volatile, news-sensitive stocks — additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. The suite launched in **July 2026**; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
 
 ### 13.5 Issuer and custodian risk (Ondo / tokenized stocks)
 
@@ -840,7 +843,8 @@ In the interest of the same candor Reserve applies to its own marketing, the mat
 - **Behind-the-meter / power-rich** — describing a site with direct, secured access to abundant (often low-cost or baseload, e.g., nuclear-adjacent) electricity; the scarcest input in the AI build-out and the core advantage of the host-side constituents.
 - **Colocation** — providing data-center space, power, and cooling in which a customer's (e.g., a neocloud's) servers/GPUs are housed and operated; Core Scientific (CORZ) is the basket's large HPC-colocation exposure.
 - **Contracted backlog** — the total future revenue under signed, multi-year customer contracts; large for several constituents but not yet earned — it depends on building and delivering the capacity on schedule.
-- **CoW Swap** — a decentralized-exchange / solver network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions; also a venue where NEOCLOUD may trade.
+- **CoW Swap** — a solver/DEX network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions, sourcing deep liquidity for onchain rebalances.
+- **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with gas-free and MEV-protected swaps; it powers swaps on PancakeSwap, and on BNB Chain it supports real-world assets (RWAs) — the category these DTFs fall into. Docs: docs.pancakeswap.finance/trade/pancakeswap-x.
 - **DTF (Decentralized Token Fund; formerly "Folio")** — a fully asset-backed ERC-20 token created with Reserve's contracts that represents a basket of underlying tokens; mint/redeemable and governed permissionlessly onchain. NEOCLOUD is an **Index DTF**.
 - **Dutch auction** — the declining-price auction mechanism Reserve uses to rebalance DTF baskets onchain.
 - **EEA (European Economic Area)** — the EU member states plus Iceland, Liechtenstein, and Norway. In these docs it appears as a "restricted" jurisdiction where the DTFs are available only to approved accredited/professional investors.
@@ -897,7 +901,7 @@ A: A **0.3% mint fee** and a **0.6% annual TVL (management) fee.** A protocol pl
 A: No minimum or maximum purchase size.
 
 **Q: How do I buy it?**
-A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on partner venues (PancakeSwap and other BNB Chain DEXs; aggregators like 1inch, CoW Swap). You must be in an eligible jurisdiction.
+A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on **PancakeSwap** (BNB Chain) via **PancakeSwap X** — gas-free and MEV-protected; on BNB Chain, PancakeSwap X supports real-world assets like these DTFs. You must be in an eligible jurisdiction.
 
 **Q: Can I buy it in the United States?**
 A: **No.** NEOCLOUD is prohibited for US persons (and US territories, Canada, and sanctioned jurisdictions). Several other places (UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil) allow it only for accredited/professional investors. Eligibility is set by Ondo.
@@ -907,6 +911,9 @@ A: Ondo Global Markets, the issuer of the underlying tokenized stocks. See docs.
 
 **Q: I'm in a restricted jurisdiction (e.g., UK, EEA, Brazil) — how do I get approved?**
 A: You can apply. In restricted jurisdictions you submit a request to be verified as an accredited/professional investor (through the app) and complete the required verification; approvals are processed by Reserve, potentially with the help of a third-party accreditation provider.
+
+**Q: How can a "decentralized" token be restricted by country? Doesn't that require KYC, which would make it centralized?**
+A: This mixes up two layers. **(1) The token/protocol layer is decentralized:** NEOCLOUD is a permissionless ERC-20 on BNB Chain — the contracts are open-source and governed onchain, anyone can mint or redeem at the value of the underlying, no central party can seize or freeze the token in your wallet, and you can always redeem onchain for the underlying assets without permission. **(2) The restriction lives one layer down, in what NEOCLOUD holds:** Ondo Global Markets tokenized stocks, each backed 1:1 by a real share in a regulated US brokerage account. Because those are actual securities, their issuer (Ondo) applies eligibility rules and transfer permissioning to comply with securities law — so "not available in country X" is set by **Ondo, the issuer of the underlying**, not by Reserve and not because the DTF is "centralized." **And it is not enforced by KYC on the token:** the basic access gate on app.reserve.org is a **wallet self-attestation** (you tick boxes confirming eligibility), tied only to your wallet address and never your personal info — Reserve does not collect or store identity documents for it. Only if you are in a *restricted* jurisdiction and want to qualify as an accredited/professional investor is there an optional verification step. In short: **the DTF wrapper is decentralized; the real-world asset it wraps carries the compliance perimeter of the real security behind it.** That is the tradeoff of tokenizing regulated assets — a real share behind every token, and the issuer's eligibility rules riding along with it. (The flip side, disclosed in Section 13.5: because it wraps Ondo's tokenized stock, you take on Ondo as an issuer — decentralized at the protocol layer, but the real-world-asset layer is not trustless.)
 
 **Q: What gives NEOCLOUD its value / how is it priced?**
 A: Its price is based on the **NAV** of its underlying tokenized stocks. Because anyone can mint/redeem at NAV onchain, arbitrage keeps the market price close to the value of the basket — though deviations can occur.
@@ -1007,4 +1014,4 @@ The third-party market-size forecasts referenced (Mordor Intelligence, Synergy R
 
 ---
 
-*Document type: LLM-generated reference for the Reserve AI Capacity & Neocloud DTF ($NEOCLOUD). Document version 0.5 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and part of the broader Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, PHOTON, ROBOTS). Verify everything on app.reserve.org before acting.*
+*Document type: LLM-generated reference for the Reserve AI Capacity & Neocloud DTF ($NEOCLOUD). Document version 0.6 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and part of the broader Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, PHOTON, ROBOTS). Verify everything on app.reserve.org before acting.*

--- a/public/dtf-llm/photon-dtf.md
+++ b/public/dtf-llm/photon-dtf.md
@@ -1,7 +1,8 @@
 ---
 title: "Reserve AI Photonics DTF ($PHOTON) — Complete Reference"
-version: "0.5"
-version_date: "2026-06-22"
+version: "0.6"
+version_date: "2026-07-08"
+launch_date: "2026-07-09"
 ticker: PHOTON
 product_type: "Index DTF (Decentralized Token Fund)"
 theme: "AI photonics — fiber, lasers, transceivers, and optical chips for AI data centers"
@@ -33,7 +34,7 @@ not_advice: "For informational purposes only. Not investment, legal, or tax advi
 
 # Reserve AI Photonics DTF ($PHOTON) — The Complete Reference
 
-> **Version 0.5** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
+> **Version 0.6** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
 
 > **⚠️ This document was generated with the assistance of a large language model (LLM).** It is a reference compiled from Reserve's published materials (reserve.org, docs.reserve.org, app.reserve.org), the official PHOTON tear sheet, and publicly reported third-party information. It is **not** investment, legal, or tax advice; it is **not** an offer or solicitation; and it may contain errors, omissions, or out-of-date figures. All numbers are **illustrative and approximate as of June 2026** and change at every quarterly rebalance and with the market. Where this document and Reserve's official sources (app.reserve.org, docs.reserve.org, and reserve.org/terms_and_conditions) disagree, **the official sources control.** Always verify on app.reserve.org before acting. See the full legal disclaimer at the end.
 
@@ -101,7 +102,7 @@ The document is organized roughly from "what is this and why does it exist" → 
 | **Rebalance** | Quarterly |
 | **Aggregate constituent market cap** | ~$456B (illustrative, basket data as of June 17, 2026) |
 | **Fees** | **0.3% mint fee** + **0.6% annual TVL (management) fee**; a protocol platform fee is taken out of those fees and used to buy and burn RSR. Onchain gas, exchange spreads, and Ondo mint/redeem terms also apply |
-| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus partner venues on BSC (e.g., PancakeSwap) and aggregators (1inch, CoW Swap); onchain, no min/max |
+| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus **PancakeSwap** on BNB Chain via **PancakeSwap X** — its aggregated, gas-free, MEV-protected trade engine (on BNB Chain, PancakeSwap X handles real-world assets like these DTFs); onchain, no min/max |
 | **How you pay** | Pay with a range of supported crypto via the app's **zapper** — **BNB, WBNB, USDT**, and other supported tokens — or mint/redeem with the exact basket tokens. USDT is one option, not the only one. |
 | **Who can buy** | Set by Ondo Global Markets. **Prohibited:** US, Canada, sanctioned jurisdictions. **Restricted (accredited/professional only):** UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil. **Elsewhere:** connect a wallet and buy, subject to your own local laws |
 | **Operator** | Reserve.org and app.reserve.org are operated by **ABC Labs, LLC**, which is **not** a bank, broker-dealer, or investment adviser and is **not** registered with the SEC, CFTC, or any financial regulator |
@@ -564,6 +565,8 @@ The single takeaway: **a tokenized stock is not legally identical to owning the 
 
 The underlying US equities trade only during US market hours, but the tokenized stocks (and PHOTON) trade **24/7**. Overnight and weekend news can move the "fair" value of the underlying companies while the official stock price is frozen, so the token can trade at a premium or discount to the last equity close and then re-converge when US markets reopen. This is a structural feature of trading an equity-backed token around the clock, and a source of the NAV-deviation risk in Section 13.4.
 
+**Actions can be limited when US markets are closed.** Because the underlying tokenized stocks track US-listed equities, minting, redeeming, and trading can be **constrained, paused, or priced conservatively outside US market hours** (nights, weekends, and US holidays). Reserve's automated liquidity management (e.g., Steer) manages pool pricing during these closures, but you may see wider spreads, thinner depth, or a given DTF being temporarily unavailable to trade after hours — so it is often best to transact during US market hours.
+
 ### 9.6 Why not just hold the tokenized stocks individually?
 
 You could, in principle, hold the nine underlying Ondo tokens directly rather than holding PHOTON. PHOTON's advantages over doing so are the same as any index wrapper: one transaction instead of nine, automatic capped market-cap weighting, automatic quarterly reconstitution, and a single position to manage — at the cost of the DTF's fees and an extra layer of smart-contract dependency. The choice is a convenience-vs-control trade-off.
@@ -588,7 +591,7 @@ This is the practical "how do I actually use it" section. **Always confirm the l
 4. Review the quote — the app's zapper (or, for PHOTON's Ondo-backed underlyings, the RFQ/intent route) converts your chosen token into the basket and mints PHOTON in one atomic transaction.
 5. Confirm the transaction in your wallet and pay gas. You now hold PHOTON.
 
-You can also buy/sell PHOTON on **partner venues** where it's available — **1inch, PancakeSwap, and CoW Swap** are named on the tear sheet — though availability and liquidity vary by venue and chain.
+You can also buy/sell PHOTON on **PancakeSwap** (BNB Chain) through **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with **gas-free, MEV-protected swaps**. On BNB Chain, PancakeSwap X supports **real-world assets (RWAs)** — exactly the category these DTFs fall into (docs.pancakeswap.finance/trade/pancakeswap-x). Availability and liquidity vary.
 
 ### 10.3 Selling
 
@@ -632,7 +635,7 @@ In short: **you can swap in and out of PHOTON with ordinary crypto — BNB, WBNB
 
 ### 10.9 Liquidity and market-making
 
-These DTFs are newly launched, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
+The suite launched on app.reserve.org on **July 9, 2026**, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
 
 ---
 
@@ -652,7 +655,7 @@ Three points that matter:
 - **Eligibility can change** as Ondo updates its rules, and verification requirements in "restricted" jurisdictions can involve a KYC/accreditation step.
 - **You are responsible for your local laws** even in "elsewhere" jurisdictions — tax, securities, and other regulations may still apply to you.
 
-**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
+**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. The app also applies **geographic access controls**: visitors from prohibited regions are shown a geo-block / eligibility modal and cannot proceed, and this platform-level geo-blocking is applied on Reserve's app (and, where implemented, on partner trading venues). Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
 
 - **Can I mint/redeem on app.reserve.org?** In a restricted jurisdiction, generally **not until you have been approved** as an accredited/professional investor (you can apply — see above). The authoritative check is **in the app**: connect your wallet and start the purchase flow and it will tell you directly whether you pass the eligibility gate.
 - **Can I just buy it on a DEX instead?** The DTF is an ERC-20 on BNB Chain, so in principle it can trade on DEXs (e.g., PancakeSwap) outside the app — **but this is not a reliable way around the eligibility rules.** The underlying Ondo tokenized stocks carry **transfer allowlists/permissioning** that can block the wrapper from moving to non-eligible wallets, and using secondary markets to circumvent the issuer's eligibility terms can conflict with **Ondo's terms** and your local rules. Don't treat it as a clean path.
@@ -711,7 +714,7 @@ The photonics thesis could be wrong or already priced in (Section 3.5): forecast
 
 ### 13.4 Tracking / NAV-deviation risk
 
-PHOTON's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** PHOTON tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7, additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. These products are newly launched; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
+PHOTON's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** PHOTON tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7, additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. The suite launched in **July 2026**; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
 
 ### 13.5 Issuer and custodian risk (Ondo / tokenized stocks)
 
@@ -833,7 +836,8 @@ In the interest of the same candor Reserve applies to its own marketing, the mat
 
 - **AI photonics** — the use of light (photons), via fiber, lasers, transceivers, and optical chips, to move data inside and between AI data centers, replacing copper electrical links as speeds rise.
 - **Basket** — the set of underlying tokens a DTF holds; for PHOTON, nine tokenized US-listed photonics stocks.
-- **CoW Swap** — a decentralized-exchange / solver network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions; also a venue where PHOTON may trade.
+- **CoW Swap** — a solver/DEX network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions, sourcing deep liquidity for onchain rebalances.
+- **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with gas-free and MEV-protected swaps; it powers swaps on PancakeSwap, and on BNB Chain it supports real-world assets (RWAs) — the category these DTFs fall into. Docs: docs.pancakeswap.finance/trade/pancakeswap-x.
 - **Co-packaged optics (CPO)** — integrating optical engines directly onto a switch chip's package for major power/density gains; a key 2025–2026 transition.
 - **DTF (Decentralized Token Fund; formerly "Folio")** — a fully asset-backed ERC-20 token created with Reserve's contracts that represents a basket of underlying tokens; mint/redeemable and governed permissionlessly onchain. PHOTON is an **Index DTF**.
 - **Dutch auction** — the declining-price auction mechanism Reserve uses to rebalance DTF baskets onchain.
@@ -888,7 +892,7 @@ A: A **0.3% mint fee** and a **0.6% annual TVL (management) fee.** A protocol pl
 A: No minimum or maximum purchase size.
 
 **Q: How do I buy it?**
-A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on partner venues (PancakeSwap and other BNB Chain DEXs; aggregators like 1inch, CoW Swap). You must be in an eligible jurisdiction.
+A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on **PancakeSwap** (BNB Chain) via **PancakeSwap X** — gas-free and MEV-protected; on BNB Chain, PancakeSwap X supports real-world assets like these DTFs. You must be in an eligible jurisdiction.
 
 **Q: Can I buy it in the United States?**
 A: **No.** PHOTON is prohibited for US persons (and US territories, Canada, and sanctioned jurisdictions). Several other places (UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil) allow it only for accredited/professional investors. Eligibility is set by Ondo.
@@ -898,6 +902,9 @@ A: Ondo Global Markets, the issuer of the underlying tokenized stocks. See docs.
 
 **Q: I'm in a restricted jurisdiction (e.g., UK, EEA, Brazil) — how do I get approved?**
 A: You can apply. In restricted jurisdictions you submit a request to be verified as an accredited/professional investor (through the app) and complete the required verification; approvals are processed by Reserve, potentially with the help of a third-party accreditation provider.
+
+**Q: How can a "decentralized" token be restricted by country? Doesn't that require KYC, which would make it centralized?**
+A: This mixes up two layers. **(1) The token/protocol layer is decentralized:** PHOTON is a permissionless ERC-20 on BNB Chain — the contracts are open-source and governed onchain, anyone can mint or redeem at the value of the underlying, no central party can seize or freeze the token in your wallet, and you can always redeem onchain for the underlying assets without permission. **(2) The restriction lives one layer down, in what PHOTON holds:** Ondo Global Markets tokenized stocks, each backed 1:1 by a real share in a regulated US brokerage account. Because those are actual securities, their issuer (Ondo) applies eligibility rules and transfer permissioning to comply with securities law — so "not available in country X" is set by **Ondo, the issuer of the underlying**, not by Reserve and not because the DTF is "centralized." **And it is not enforced by KYC on the token:** the basic access gate on app.reserve.org is a **wallet self-attestation** (you tick boxes confirming eligibility), tied only to your wallet address and never your personal info — Reserve does not collect or store identity documents for it. Only if you are in a *restricted* jurisdiction and want to qualify as an accredited/professional investor is there an optional verification step. In short: **the DTF wrapper is decentralized; the real-world asset it wraps carries the compliance perimeter of the real security behind it.** That is the tradeoff of tokenizing regulated assets — a real share behind every token, and the issuer's eligibility rules riding along with it. (The flip side, disclosed in Section 13.5: because it wraps Ondo's tokenized stock, you take on Ondo as an issuer — decentralized at the protocol layer, but the real-world-asset layer is not trustless.)
 
 **Q: What gives PHOTON its value / how is it priced?**
 A: Its price is based on the **NAV** of its underlying tokenized stocks. Because anyone can mint/redeem at NAV onchain, arbitrage keeps the market price close to the value of the basket — though deviations can occur.
@@ -990,4 +997,4 @@ The third-party market-size forecasts referenced (Goldman Sachs and others) are 
 
 ---
 
-*Document type: LLM-generated reference for the Reserve AI Photonics DTF ($PHOTON). Document version 0.5 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and a template for the broader Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, ROBOTS). Verify everything on app.reserve.org before acting.*
+*Document type: LLM-generated reference for the Reserve AI Photonics DTF ($PHOTON). Document version 0.6 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and a template for the broader Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, ROBOTS). Verify everything on app.reserve.org before acting.*

--- a/public/dtf-llm/power-dtf.md
+++ b/public/dtf-llm/power-dtf.md
@@ -1,7 +1,8 @@
 ---
 title: "Reserve AI Power DTF ($POWER) — Complete Reference"
-version: "0.5"
-version_date: "2026-06-22"
+version: "0.6"
+version_date: "2026-07-08"
+launch_date: "2026-07-09"
 ticker: POWER
 product_type: "Index DTF (Decentralized Token Fund)"
 theme: "AI power — gas turbines, nuclear, grid & electrical equipment, and power chips for AI data centers"
@@ -33,7 +34,7 @@ not_advice: "For informational purposes only. Not investment, legal, or tax advi
 
 # Reserve AI Power DTF ($POWER) — The Complete Reference
 
-> **Version 0.5** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
+> **Version 0.6** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
 
 > **⚠️ This document was generated with the assistance of a large language model (LLM).** It is a reference compiled from Reserve's published materials (reserve.org, docs.reserve.org, app.reserve.org), the official POWER tear sheet, and publicly reported third-party information. It is **not** investment, legal, or tax advice; it is **not** an offer or solicitation; and it may contain errors, omissions, or out-of-date figures. All numbers are **illustrative and approximate as of June 2026** and change at every quarterly rebalance and with the market. Where this document and Reserve's official sources (app.reserve.org, docs.reserve.org, and reserve.org/terms_and_conditions) disagree, **the official sources control.** Always verify on app.reserve.org before acting. See the full legal disclaimer at the end.
 
@@ -101,7 +102,7 @@ The document is organized roughly from "what is this and why does it exist" → 
 | **Rebalance** | Quarterly |
 | **Aggregate constituent market cap** | ~$1.02T (illustrative, basket data as of June 17, 2026) |
 | **Fees** | **0.3% mint fee** + **0.6% annual TVL (management) fee**; a protocol platform fee is taken out of those fees and used to buy and burn RSR. Onchain gas, exchange spreads, and Ondo mint/redeem terms also apply |
-| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus partner venues on BSC (e.g., PancakeSwap) and aggregators (1inch, CoW Swap); onchain, no min/max |
+| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus **PancakeSwap** on BNB Chain via **PancakeSwap X** — its aggregated, gas-free, MEV-protected trade engine (on BNB Chain, PancakeSwap X handles real-world assets like these DTFs); onchain, no min/max |
 | **How you pay** | Pay with a range of supported crypto via the app's **zapper** — **BNB, WBNB, USDT**, and other supported tokens — or mint/redeem with the exact basket tokens. USDT is one option, not the only one. |
 | **Who can buy** | Set by Ondo Global Markets. **Prohibited:** US, Canada, sanctioned jurisdictions. **Restricted (accredited/professional only):** UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil. **Elsewhere:** connect a wallet and buy, subject to your own local laws |
 | **Operator** | Reserve.org and app.reserve.org are operated by **ABC Labs, LLC**, which is **not** a bank, broker-dealer, or investment adviser and is **not** registered with the SEC, CFTC, or any financial regulator |
@@ -632,6 +633,8 @@ The single takeaway: **a tokenized stock is not legally identical to owning the 
 
 The underlying US equities trade only during US market hours, but the tokenized stocks (and POWER) trade **24/7**. Overnight and weekend news can move the "fair" value of the underlying companies while the official stock price is frozen, so the token can trade at a premium or discount to the last equity close and then re-converge when US markets reopen. This is a structural feature of trading an equity-backed token around the clock, and a source of the NAV-deviation risk in Section 13.4.
 
+**Actions can be limited when US markets are closed.** Because the underlying tokenized stocks track US-listed equities, minting, redeeming, and trading can be **constrained, paused, or priced conservatively outside US market hours** (nights, weekends, and US holidays). Reserve's automated liquidity management (e.g., Steer) manages pool pricing during these closures, but you may see wider spreads, thinner depth, or a given DTF being temporarily unavailable to trade after hours — so it is often best to transact during US market hours.
+
 ### 9.6 Why not just hold the tokenized stocks individually?
 
 You could, in principle, hold the thirteen underlying Ondo tokens directly rather than holding POWER. POWER's advantages over doing so are the same as any index wrapper: one transaction instead of thirteen, automatic capped market-cap weighting, automatic quarterly reconstitution, and a single position to manage — at the cost of the DTF's fees and an extra layer of smart-contract dependency. The choice is a convenience-vs-control trade-off.
@@ -656,7 +659,7 @@ This is the practical "how do I actually use it" section. **Always confirm the l
 4. Review the quote — the app's zapper (or, for POWER's Ondo-backed underlyings, the RFQ/intent route) converts your chosen token into the basket and mints POWER in one atomic transaction.
 5. Confirm the transaction in your wallet and pay gas. You now hold POWER.
 
-You can also buy/sell POWER on **partner venues** where it's available — **1inch, PancakeSwap, and CoW Swap** are named on the tear sheet — though availability and liquidity vary by venue and chain.
+You can also buy/sell POWER on **PancakeSwap** (BNB Chain) through **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with **gas-free, MEV-protected swaps**. On BNB Chain, PancakeSwap X supports **real-world assets (RWAs)** — exactly the category these DTFs fall into (docs.pancakeswap.finance/trade/pancakeswap-x). Availability and liquidity vary.
 
 ### 10.3 Selling
 
@@ -700,7 +703,7 @@ In short: **you can swap in and out of POWER with ordinary crypto — BNB, WBNB,
 
 ### 10.9 Liquidity and market-making
 
-These DTFs are newly launched, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
+The suite launched on app.reserve.org on **July 9, 2026**, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
 
 ---
 
@@ -720,7 +723,7 @@ Three points that matter:
 - **Eligibility can change** as Ondo updates its rules, and verification requirements in "restricted" jurisdictions can involve a KYC/accreditation step.
 - **You are responsible for your local laws** even in "elsewhere" jurisdictions — tax, securities, and other regulations may still apply to you.
 
-**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
+**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. The app also applies **geographic access controls**: visitors from prohibited regions are shown a geo-block / eligibility modal and cannot proceed, and this platform-level geo-blocking is applied on Reserve's app (and, where implemented, on partner trading venues). Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
 
 - **Can I mint/redeem on app.reserve.org?** In a restricted jurisdiction, generally **not until you have been approved** as an accredited/professional investor (you can apply — see above). The authoritative check is **in the app**: connect your wallet and start the purchase flow and it will tell you directly whether you pass the eligibility gate.
 - **Can I just buy it on a DEX instead?** The DTF is an ERC-20 on BNB Chain, so in principle it can trade on DEXs (e.g., PancakeSwap) outside the app — **but this is not a reliable way around the eligibility rules.** The underlying Ondo tokenized stocks carry **transfer allowlists/permissioning** that can block the wrapper from moving to non-eligible wallets, and using secondary markets to circumvent the issuer's eligibility terms can conflict with **Ondo's terms** and your local rules. Don't treat it as a clean path.
@@ -787,7 +790,7 @@ The AI-power thesis could be wrong or already priced in (Section 3.6). Several t
 
 ### 13.4 Tracking / NAV-deviation risk
 
-POWER's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** POWER tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7, additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. These products are newly launched; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
+POWER's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** POWER tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7, additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. The suite launched in **July 2026**; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
 
 ### 13.5 Issuer and custodian risk (Ondo / tokenized stocks)
 
@@ -911,7 +914,8 @@ In the interest of the same candor Reserve applies to its own marketing, the mat
 - **Baseload** — the steady, always-on electricity supply that a large continuous load (like an AI data center) depends on; nuclear and gas are the firm baseload sources central to the AI-power thesis.
 - **Basket** — the set of underlying tokens a DTF holds; for POWER, thirteen tokenized US-listed AI-power stocks.
 - **Behind-the-meter (BTM)** — power generated on-site at a facility and consumed without crossing the public utility meter, letting operators bypass grid-interconnection queues; Bloom Energy's fuel cells and some Powell/Talen arrangements are examples.
-- **CoW Swap** — a decentralized-exchange / solver network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions; also a venue where POWER may trade.
+- **CoW Swap** — a solver/DEX network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions, sourcing deep liquidity for onchain rebalances.
+- **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with gas-free and MEV-protected swaps; it powers swaps on PancakeSwap, and on BNB Chain it supports real-world assets (RWAs) — the category these DTFs fall into. Docs: docs.pancakeswap.finance/trade/pancakeswap-x.
 - **DTF (Decentralized Token Fund; formerly "Folio")** — a fully asset-backed ERC-20 token created with Reserve's contracts that represents a basket of underlying tokens; mint/redeemable and governed permissionlessly onchain. POWER is an **Index DTF**.
 - **Dutch auction** — the declining-price auction mechanism Reserve uses to rebalance DTF baskets onchain.
 - **EEA (European Economic Area)** — the EU member states plus Iceland, Liechtenstein, and Norway. In these docs it appears as a "restricted" jurisdiction where the DTFs are available only to approved accredited/professional investors.
@@ -969,7 +973,7 @@ A: A **0.3% mint fee** and a **0.6% annual TVL (management) fee.** A protocol pl
 A: No minimum or maximum purchase size.
 
 **Q: How do I buy it?**
-A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on partner venues (PancakeSwap and other BNB Chain DEXs; aggregators like 1inch, CoW Swap). You must be in an eligible jurisdiction.
+A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on **PancakeSwap** (BNB Chain) via **PancakeSwap X** — gas-free and MEV-protected; on BNB Chain, PancakeSwap X supports real-world assets like these DTFs. You must be in an eligible jurisdiction.
 
 **Q: Can I buy it in the United States?**
 A: **No.** POWER is prohibited for US persons (and US territories, Canada, and sanctioned jurisdictions). Several other places (UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil) allow it only for accredited/professional investors. Eligibility is set by Ondo.
@@ -979,6 +983,9 @@ A: Ondo Global Markets, the issuer of the underlying tokenized stocks. See docs.
 
 **Q: I'm in a restricted jurisdiction (e.g., UK, EEA, Brazil) — how do I get approved?**
 A: You can apply. In restricted jurisdictions you submit a request to be verified as an accredited/professional investor (through the app) and complete the required verification; approvals are processed by Reserve, potentially with the help of a third-party accreditation provider.
+
+**Q: How can a "decentralized" token be restricted by country? Doesn't that require KYC, which would make it centralized?**
+A: This mixes up two layers. **(1) The token/protocol layer is decentralized:** POWER is a permissionless ERC-20 on BNB Chain — the contracts are open-source and governed onchain, anyone can mint or redeem at the value of the underlying, no central party can seize or freeze the token in your wallet, and you can always redeem onchain for the underlying assets without permission. **(2) The restriction lives one layer down, in what POWER holds:** Ondo Global Markets tokenized stocks, each backed 1:1 by a real share in a regulated US brokerage account. Because those are actual securities, their issuer (Ondo) applies eligibility rules and transfer permissioning to comply with securities law — so "not available in country X" is set by **Ondo, the issuer of the underlying**, not by Reserve and not because the DTF is "centralized." **And it is not enforced by KYC on the token:** the basic access gate on app.reserve.org is a **wallet self-attestation** (you tick boxes confirming eligibility), tied only to your wallet address and never your personal info — Reserve does not collect or store identity documents for it. Only if you are in a *restricted* jurisdiction and want to qualify as an accredited/professional investor is there an optional verification step. In short: **the DTF wrapper is decentralized; the real-world asset it wraps carries the compliance perimeter of the real security behind it.** That is the tradeoff of tokenizing regulated assets — a real share behind every token, and the issuer's eligibility rules riding along with it. (The flip side, disclosed in Section 13.5: because it wraps Ondo's tokenized stock, you take on Ondo as an issuer — decentralized at the protocol layer, but the real-world-asset layer is not trustless.)
 
 **Q: What gives POWER its value / how is it priced?**
 A: Its price is based on the **NAV** of its underlying tokenized stocks. Because anyone can mint/redeem at NAV onchain, arbitrage keeps the market price close to the value of the basket — though deviations can occur.
@@ -1070,4 +1077,4 @@ The third-party market-size forecasts referenced (Goldman Sachs and others) are 
 
 ---
 
-*Document type: LLM-generated reference for the Reserve AI Power DTF ($POWER). Document version 0.5 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and part of the broader Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, ROBOTS, PHOTON). Verify everything on app.reserve.org before acting.*
+*Document type: LLM-generated reference for the Reserve AI Power DTF ($POWER). Document version 0.6 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and part of the broader Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, ROBOTS, PHOTON). Verify everything on app.reserve.org before acting.*

--- a/public/dtf-llm/robots-dtf.md
+++ b/public/dtf-llm/robots-dtf.md
@@ -1,7 +1,8 @@
 ---
 title: "Reserve Robotics DTF ($ROBOTS) — Complete Reference"
-version: "0.5"
-version_date: "2026-06-22"
+version: "0.6"
+version_date: "2026-07-08"
+launch_date: "2026-07-09"
 ticker: ROBOTS
 product_type: "Index DTF (Decentralized Token Fund)"
 theme: "Robotics & automation — AI moving off the screen into the physical world: humanoids, surgical robots, factory & warehouse automation, lidar, machine vision, and autonomy"
@@ -33,7 +34,7 @@ not_advice: "For informational purposes only. Not investment, legal, or tax advi
 
 # Reserve Robotics DTF ($ROBOTS) — The Complete Reference
 
-> **Version 0.5** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
+> **Version 0.6** — draft of this reference document (auto-generated, pending human and legal review). Structure, wording, and figures may change in later versions.
 
 > **⚠️ This document was generated with the assistance of a large language model (LLM).** It is a reference compiled from Reserve's published materials (reserve.org, docs.reserve.org, app.reserve.org), the official ROBOTS tear sheet, and publicly reported third-party information. It is **not** investment, legal, or tax advice; it is **not** an offer or solicitation; and it may contain errors, omissions, or out-of-date figures. All numbers are **illustrative and approximate as of June 2026** and change at every quarterly rebalance and with the market. Where this document and Reserve's official sources (app.reserve.org, docs.reserve.org, and reserve.org/terms_and_conditions) disagree, **the official sources control.** Always verify on app.reserve.org before acting. See the full legal disclaimer at the end.
 
@@ -101,7 +102,7 @@ The document is organized roughly from "what is this and why does it exist" → 
 | **Rebalance** | Quarterly |
 | **Aggregate constituent market cap** | ~$272B (illustrative, basket data as of June 17, 2026) |
 | **Fees** | **0.3% mint fee** + **0.6% annual TVL (management) fee**; a protocol platform fee is taken out of those fees and used to buy and burn RSR. Onchain gas, exchange spreads, and Ondo mint/redeem terms also apply |
-| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus partner venues on BSC (e.g., PancakeSwap) and aggregators (1inch, CoW Swap); onchain, no min/max |
+| **Where to trade** | app.reserve.org (mint/redeem + buy/sell), plus **PancakeSwap** on BNB Chain via **PancakeSwap X** — its aggregated, gas-free, MEV-protected trade engine (on BNB Chain, PancakeSwap X handles real-world assets like these DTFs); onchain, no min/max |
 | **How you pay** | Pay with a range of supported crypto via the app's **zapper** — **BNB, WBNB, USDT**, and other supported tokens — or mint/redeem with the exact basket tokens. USDT is one option, not the only one. |
 | **Who can buy** | Set by Ondo Global Markets. **Prohibited:** US, Canada, sanctioned jurisdictions. **Restricted (accredited/professional only):** UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil. **Elsewhere:** connect a wallet and buy, subject to your own local laws |
 | **Operator** | Reserve.org and app.reserve.org are operated by **ABC Labs, LLC**, which is **not** a bank, broker-dealer, or investment adviser and is **not** registered with the SEC, CFTC, or any financial regulator |
@@ -578,6 +579,8 @@ The single takeaway: **a tokenized stock is not legally identical to owning the 
 
 The underlying US equities trade only during US market hours, but the tokenized stocks (and ROBOTS) trade **24/7**. Overnight and weekend news can move the "fair" value of the underlying companies while the official stock price is frozen, so the token can trade at a premium or discount to the last equity close and then re-converge when US markets reopen. This is a structural feature of trading an equity-backed token around the clock, and a source of the NAV-deviation risk in Section 13.4.
 
+**Actions can be limited when US markets are closed.** Because the underlying tokenized stocks track US-listed equities, minting, redeeming, and trading can be **constrained, paused, or priced conservatively outside US market hours** (nights, weekends, and US holidays). Reserve's automated liquidity management (e.g., Steer) manages pool pricing during these closures, but you may see wider spreads, thinner depth, or a given DTF being temporarily unavailable to trade after hours — so it is often best to transact during US market hours.
+
 ### 9.6 Why not just hold the tokenized stocks individually?
 
 You could, in principle, hold the nine underlying Ondo tokens directly rather than holding ROBOTS. ROBOTS's advantages over doing so are the same as any index wrapper: one transaction instead of nine, automatic capped market-cap weighting, automatic quarterly reconstitution, and a single position to manage — at the cost of the DTF's fees and an extra layer of smart-contract dependency. The choice is a convenience-vs-control trade-off.
@@ -602,7 +605,7 @@ This is the practical "how do I actually use it" section. **Always confirm the l
 4. Review the quote — the app's zapper (or, for ROBOTS's Ondo-backed underlyings, the RFQ/intent route) converts your chosen token into the basket and mints ROBOTS in one atomic transaction.
 5. Confirm the transaction in your wallet and pay gas. You now hold ROBOTS.
 
-You can also buy/sell ROBOTS on **partner venues** where it's available — **1inch, PancakeSwap, and CoW Swap** are named on the tear sheet — though availability and liquidity vary by venue and chain.
+You can also buy/sell ROBOTS on **PancakeSwap** (BNB Chain) through **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with **gas-free, MEV-protected swaps**. On BNB Chain, PancakeSwap X supports **real-world assets (RWAs)** — exactly the category these DTFs fall into (docs.pancakeswap.finance/trade/pancakeswap-x). Availability and liquidity vary.
 
 ### 10.3 Selling
 
@@ -646,7 +649,7 @@ In short: **you can swap in and out of ROBOTS with ordinary crypto — BNB, WBNB
 
 ### 10.9 Liquidity and market-making
 
-These DTFs are newly launched, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
+The suite launched on app.reserve.org on **July 9, 2026**, so onchain liquidity and trading history are still building — but liquidity was **planned and provisioned as part of the launch**, not left to chance. Reserve **seeded onchain liquidity** for the DTFs at launch and engaged **professional market makers** to quote two-sided markets, uses **automated liquidity management** (e.g., Steer vaults) to maintain pool depth, and runs **liquidity-incentive programs** (e.g., Merkl) to attract and sustain TVL. Rebalances additionally source deep liquidity through the **CoW Swap** solver network with permissionless bidding (Section 8.5). The honest caveat still stands: as a freshly launched product, depth is thinner than in a mature market, so larger orders can see more slippage and a wider gap to underlying NAV — check live depth and quotes in the app before sizing a trade.
 
 ---
 
@@ -666,7 +669,7 @@ Three points that matter:
 - **Eligibility can change** as Ondo updates its rules, and verification requirements in "restricted" jurisdictions can involve a KYC/accreditation step.
 - **You are responsible for your local laws** even in "elsewhere" jurisdictions — tax, securities, and other regulations may still apply to you.
 
-**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
+**How eligibility is enforced in the app.** Before you can mint/buy on app.reserve.org you pass a **wallet-based self-attestation**: you check boxes confirming you have read the Terms of Use, that you are **not** located in, a resident of, or a citizen of a restricted jurisdiction, and that you are permitted to purchase tokenized stocks under your local laws. Per the app, this confirmation is **only ever associated with your wallet address — never your personal information**; Reserve/ABC Labs does not collect or store personal identity documents for this basic gate. The app also applies **geographic access controls**: visitors from prohibited regions are shown a geo-block / eligibility modal and cannot proceed, and this platform-level geo-blocking is applied on Reserve's app (and, where implemented, on partner trading venues). Separately, where a **restricted** jurisdiction requires accredited/professional status, you can **apply to be approved** through a request-and-verification process (see Section 11). Separately, this also resolves a common point of confusion for users in **restricted** jurisdictions (for example, a resident of an **EEA** country — the European Economic Area, i.e., the EU member states plus Iceland, Liechtenstein, and Norway — who is **not** an accredited/professional investor):
 
 - **Can I mint/redeem on app.reserve.org?** In a restricted jurisdiction, generally **not until you have been approved** as an accredited/professional investor (you can apply — see above). The authoritative check is **in the app**: connect your wallet and start the purchase flow and it will tell you directly whether you pass the eligibility gate.
 - **Can I just buy it on a DEX instead?** The DTF is an ERC-20 on BNB Chain, so in principle it can trade on DEXs (e.g., PancakeSwap) outside the app — **but this is not a reliable way around the eligibility rules.** The underlying Ondo tokenized stocks carry **transfer allowlists/permissioning** that can block the wrapper from moving to non-eligible wallets, and using secondary markets to circumvent the issuer's eligibility terms can conflict with **Ondo's terms** and your local rules. Don't treat it as a clean path.
@@ -725,7 +728,7 @@ The robotics & automation thesis could be wrong, mistimed, or already priced in 
 
 ### 13.4 Tracking / NAV-deviation risk
 
-ROBOTS's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** ROBOTS tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7, additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. These products are newly launched; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
+ROBOTS's market price can **trade above or below** the value of its underlying basket. Weights **drift between quarterly rebalances**, so the live basket differs from the published targets. There is **no guarantee** ROBOTS tracks its intended basket. Because the underlying tokenized stocks are offchain-liquid and the equities trade only during US market hours while the token trades 24/7, additional price dislocations can occur. Arbitrage (permissionless mint/redeem) reduces but does not eliminate these gaps. The suite launched in **July 2026**; liquidity was seeded and market makers engaged at launch to mitigate this (Section 10.9), but depth is still building, which can widen slippage and NAV gaps.
 
 ### 13.5 Issuer and custodian risk (Ondo / tokenized stocks)
 
@@ -848,7 +851,8 @@ In the interest of the same candor Reserve applies to its own marketing, the mat
 - **ADAS (advanced driver-assistance systems)** — vision/sensor-based systems that assist or partially automate driving (lane-keeping, adaptive cruise, hands-free highway driving); the bridge from human-driven cars to full autonomy. Mobileye (MBLY) is the basket's primary ADAS exposure.
 - **Autonomy / self-driving** — software and systems that let a vehicle perceive, decide, and drive itself, from driver-assistance up to fully driverless operation. Aurora (AUR) and Mobileye (MBLY) are the basket's autonomy names.
 - **Basket** — the set of underlying tokens a DTF holds; for ROBOTS, nine tokenized US-listed robotics & automation stocks.
-- **CoW Swap** — a decentralized-exchange / solver network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions; also a venue where ROBOTS may trade.
+- **CoW Swap** — a solver/DEX network integrated as a "Trusted Filler" for Reserve Index DTF rebalance auctions, sourcing deep liquidity for onchain rebalances.
+- **PancakeSwap X** — PancakeSwap's trading engine that aggregates third-party liquidity for better prices, with gas-free and MEV-protected swaps; it powers swaps on PancakeSwap, and on BNB Chain it supports real-world assets (RWAs) — the category these DTFs fall into. Docs: docs.pancakeswap.finance/trade/pancakeswap-x.
 - **DTF (Decentralized Token Fund; formerly "Folio")** — a fully asset-backed ERC-20 token created with Reserve's contracts that represents a basket of underlying tokens; mint/redeemable and governed permissionlessly onchain. ROBOTS is an **Index DTF**.
 - **Dutch auction** — the declining-price auction mechanism Reserve uses to rebalance DTF baskets onchain.
 - **EEA (European Economic Area)** — the EU member states plus Iceland, Liechtenstein, and Norway. In these docs it appears as a "restricted" jurisdiction where the DTFs are available only to approved accredited/professional investors.
@@ -908,7 +912,7 @@ A: A **0.3% mint fee** and a **0.6% annual TVL (management) fee.** A protocol pl
 A: No minimum or maximum purchase size.
 
 **Q: How do I buy it?**
-A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on partner venues (PancakeSwap and other BNB Chain DEXs; aggregators like 1inch, CoW Swap). You must be in an eligible jurisdiction.
+A: On app.reserve.org — connect a wallet, click Buy, and pay with a supported token (BNB, WBNB, USDT, etc.) via the zapper — or on **PancakeSwap** (BNB Chain) via **PancakeSwap X** — gas-free and MEV-protected; on BNB Chain, PancakeSwap X supports real-world assets like these DTFs. You must be in an eligible jurisdiction.
 
 **Q: Can I buy it in the United States?**
 A: **No.** ROBOTS is prohibited for US persons (and US territories, Canada, and sanctioned jurisdictions). Several other places (UK, EEA, Switzerland, Singapore, Hong Kong, Malaysia, Brazil) allow it only for accredited/professional investors. Eligibility is set by Ondo.
@@ -918,6 +922,9 @@ A: Ondo Global Markets, the issuer of the underlying tokenized stocks. See docs.
 
 **Q: I'm in a restricted jurisdiction (e.g., UK, EEA, Brazil) — how do I get approved?**
 A: You can apply. In restricted jurisdictions you submit a request to be verified as an accredited/professional investor (through the app) and complete the required verification; approvals are processed by Reserve, potentially with the help of a third-party accreditation provider.
+
+**Q: How can a "decentralized" token be restricted by country? Doesn't that require KYC, which would make it centralized?**
+A: This mixes up two layers. **(1) The token/protocol layer is decentralized:** ROBOTS is a permissionless ERC-20 on BNB Chain — the contracts are open-source and governed onchain, anyone can mint or redeem at the value of the underlying, no central party can seize or freeze the token in your wallet, and you can always redeem onchain for the underlying assets without permission. **(2) The restriction lives one layer down, in what ROBOTS holds:** Ondo Global Markets tokenized stocks, each backed 1:1 by a real share in a regulated US brokerage account. Because those are actual securities, their issuer (Ondo) applies eligibility rules and transfer permissioning to comply with securities law — so "not available in country X" is set by **Ondo, the issuer of the underlying**, not by Reserve and not because the DTF is "centralized." **And it is not enforced by KYC on the token:** the basic access gate on app.reserve.org is a **wallet self-attestation** (you tick boxes confirming eligibility), tied only to your wallet address and never your personal info — Reserve does not collect or store identity documents for it. Only if you are in a *restricted* jurisdiction and want to qualify as an accredited/professional investor is there an optional verification step. In short: **the DTF wrapper is decentralized; the real-world asset it wraps carries the compliance perimeter of the real security behind it.** That is the tradeoff of tokenizing regulated assets — a real share behind every token, and the issuer's eligibility rules riding along with it. (The flip side, disclosed in Section 13.5: because it wraps Ondo's tokenized stock, you take on Ondo as an issuer — decentralized at the protocol layer, but the real-world-asset layer is not trustless.)
 
 **Q: What gives ROBOTS its value / how is it priced?**
 A: Its price is based on the **NAV** of its underlying tokenized stocks. Because anyone can mint/redeem at NAV onchain, arbitrage keeps the market price close to the value of the basket — though deviations can occur.
@@ -1009,4 +1016,4 @@ The third-party market-size forecasts referenced (Morgan Stanley, Goldman Sachs,
 
 ---
 
-*Document type: LLM-generated reference for the Reserve Robotics DTF ($ROBOTS). Document version 0.5 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and part of the broader Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, PHOTON, ROBOTS). Verify everything on app.reserve.org before acting.*
+*Document type: LLM-generated reference for the Reserve Robotics DTF ($ROBOTS). Document version 0.6 · Compiled by starl3xx, with LLM assistance · Data as of June 2026. This is a living document and part of the broader Reserve AI DTF suite (BUILDOUT, POWER, NEOCLOUD, PHOTON, ROBOTS). Verify everything on app.reserve.org before acting.*


### PR DESCRIPTION
Updates the per-DTF LLM reference docs to **v0.6**, reflecting the **July 9, 2026** launch of the Reserve Thematic AI DTF Suite on app.reserve.org.

## Changes
- **All five docs** (`photon`, `buildout`, `power`, `neocloud`, `robots`): version 0.5 → 0.6, updated version/launch dates, and reworded the liquidity/launch language from "newly launched, pending" to the confirmed July 9, 2026 launch.
- **`llms.txt`**: version bump (×2) and added the suite launch date to the "About the suite" section. Hosted `app.reserve.org/dtf-llm/` links preserved.
- **`index.json`**: version → 0.6, `generated` date refreshed, and per-doc `bytes` recomputed.

No structural changes; docs-only static assets under `public/dtf-llm/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated product reference docs to version 0.6 with refreshed launch metadata and clearer guidance.
  * Added PancakeSwap X as the primary trading venue in user-facing trade and buy instructions.

* **Bug Fixes**
  * Clarified when minting, redeeming, or trading may be limited outside U.S. market hours.
  * Improved eligibility and access messaging for restricted regions, including wallet-based confirmation and geo-blocking.
  * Refreshed liquidity, NAV, and FAQ language to better reflect the July 2026 launch and current market conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->