### PR TITLE
hotfix: use prod url

### DIFF
--- a/src/hooks/useIndexDTFList.ts
+++ b/src/hooks/useIndexDTFList.ts
@@ -1,9 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { Address } from 'viem'
 
-// TODO: Swap to the production API once the optimized discover response is live.
 const INDEX_DTFS_URL =
-  'https://api-staging.reserve.org/v1/discover/dtfs?performance=true&brand=true'
+  'https://api.reserve.org/v1/discover/dtfs?performance=true&brand=true'
 
 type Performance = { timestamp: number; value: number }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -18,8 +18,7 @@ const isStaging =
     import.meta.env.VITE_USE_STAGING) &&
   import.meta.env.VITE_STAGING_API
 
-// TODO: USE PROD BEFORE RELEASING
-export const RESERVE_API = true // isStaging
+export const RESERVE_API = isStaging
   ? import.meta.env.VITE_STAGING_API
   : 'https://api.reserve.org/'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated data fetching to use the production Reserve API endpoint instead of the staging endpoint.
  * Corrected API base URL selection at runtime so it now follows the current environment instead of always using the staging path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->