### PR TITLE
Fix vote-lock APR mismatch across DTF pages and earn

### DIFF
--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -51,7 +51,7 @@ Base URL: `https://api.reserve.org`
 | `GET /v2/historical/dtf/candles` | Candlestick OHLC series | `address`, `chainId`, `from`, `to`, `interval` | `src/views/index-dtf/overview/components/charts/use-candlestick-data.ts` |
 | `GET /v1/dtf/apy/historical/:id` | Yield-index hybrid APY history | `chainId` | `src/views/index-dtf/overview/hooks/use-dtf-apy-history.ts` |
 | `GET /historical/prices` | Token price history | `chainId`, `address`, `from`, `to`, `interval` | `src/hooks/useSimulatedBasket.ts` |
-| `GET /dtf/daos` | Vote-lock positions + yields (list, or `/dtf/daos/:id` per-DTF) | `chainId` | `src/views/earn/views/index-dtf/hooks/use-vote-lock-positions.ts`, `overview/hooks/use-staking-vault-apy.ts` |
+| `GET /dtf/daos` | Vote-lock positions + yields (list, or `/dtf/daos/:id` per-DTF fallback) | `chainId` | `src/views/earn/views/index-dtf/hooks/use-vote-lock-positions.ts`, `overview/hooks/use-staking-vault-apy.ts` |
 | `GET /v1/portfolio/:address` | Cross-DTF wallet balances | — | `src/views/portfolio-page/hooks/use-portfolio.ts` |
 | `GET /v1/historical/portfolio/:address` | Portfolio value history | `period` | `src/views/portfolio-page/hooks/use-historical-portfolio.ts` |
 

--- a/docs/wiki/progress.md
+++ b/docs/wiki/progress.md
@@ -1,6 +1,6 @@
 ---
 title: Progress
-updated: 2026-07-24
+updated: 2026-07-27
 type: ledger
 ---
 
@@ -10,6 +10,7 @@ Stage ledger. One row per stage; keep entries short. Verifier = exact fresh comm
 
 | Stage | Status | Verifier | Review | Next |
 |---|---|---|---|---|
+| vote-lock APR unified on /dtf/daos list | done (base 771c92873) | gate-equivalent green (lint/typecheck/unit, 70 helper, 56 smoke, wiki-lint) · live visual: BUILDOUT + POWER overviews and earn all 46.83% from one list request | Dark + Light, per-claim verify — adopted: list-miss/error fallback gating, plain-data return, catalog mixed-case normalization; API re-key REVERTED by Luis (sdk `getVoteLockDao` needs the DTF-address key); accepted: unlisted DTFs keep per-DTF detail cache split | pre-existing reserve-api debt flagged, not shipped: maxAge-before-await caches 500s 24h; unguarded `underlyingPrice.price` deref can 500 whole list |
 | merge master RFQ into feature hardening | human-review-required (base 0237e747c; merged `origin/master` 981b634d7; observed CLS explicitly out of scope) | frozen install · scoped gate-equivalent: lint/typecheck, 832 unit, 70 helper, 56 smoke + 1 known fixme · zap 21 · production build · wiki-lint pending | Dark + Light pass; SDK 0.5.0 pin + zapper 2.7.1 reconciled; hardening guards preserved; engineer review required for live RFQ/intent execution | commit merge locally; do not push |
 | Hardening × SDK-integration effort — sanitizer/e2e foundation · overview SDK adoption + portfolio governance-state adoption · crash + money-display guards · rebalance launch guards | **ready for master PR** (stacked PRs merged; SDK 0.5.0 pinned exact; master merged 2026-07-23) | typecheck 0 · unit green · smoke 56 · full flows green · wiki-lint green; guards revert-verified at their seams | cross-reviews reconciled in docs/claude-hardening-review.md; release blockers fixed + pinned (malformed portfolio rows incl. optimistic context, manage-weights fail-closed, zap max) | master PR on go; queue in docs/plans/FOLLOWUPS.md |
 | E2E suite: offline playwright foundation → 3-dim domain coverage → yield replay → chain-scoped identity + trust hardening | done (2026-07-05→12) | flows/smokes/helper units green at every stage; zero-unmocked teardown enforced | audits converged (log ≤2026-07-12); recipes in e2e/CLAUDE.md + [[e2e]] | stages 2–5 in § E2E coverage debt below |

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@rainbow-me/rainbowkit": "^2.2.10",
     "@reserve-protocol/async-zap-sdk": "^0.8.0",
+    "@reserve-protocol/dtf-catalog": "^0.1.3",
     "@reserve-protocol/dtf-chat": "^0.0.6",
     "@reserve-protocol/dtf-rebalance-lib": "^3.2.1",
     "@reserve-protocol/react-sdk": "0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@reserve-protocol/async-zap-sdk':
         specifier: ^0.8.0
         version: 0.8.0(@tanstack/react-query@5.99.0(react@18.3.1))(ajv@8.18.0)(cross-fetch@4.1.0)(multiformats@14.0.0)(react@18.3.1)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
+      '@reserve-protocol/dtf-catalog':
+        specifier: ^0.1.3
+        version: 0.1.3
       '@reserve-protocol/dtf-chat':
         specifier: ^0.0.6
         version: 0.0.6(@ai-sdk/react@2.0.199(react@18.3.1)(zod@4.3.6))(ai@5.0.197(zod@4.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/views/earn/views/index-dtf/hooks/use-vote-lock-positions.ts
+++ b/src/views/earn/views/index-dtf/hooks/use-vote-lock-positions.ts
@@ -28,7 +28,7 @@ export type VoteLockPosition = {
   apr: number
 }
 
-const useVoteLockPositions = () => {
+const useVoteLockPositions = (options?: { enabled?: boolean }) => {
   return useQuery({
     queryKey: ['vote-lock-positions'],
     queryFn: async () => {
@@ -41,6 +41,7 @@ const useVoteLockPositions = () => {
       return data as VoteLockPosition[]
     },
     staleTime: 1000 * 60 * 10, // 10 minutes
+    enabled: options?.enabled ?? true,
   })
 }
 

--- a/src/views/index-dtf/overview/hooks/use-staking-vault-apy.ts
+++ b/src/views/index-dtf/overview/hooks/use-staking-vault-apy.ts
@@ -1,29 +1,70 @@
 import { indexDTFAtom } from '@/state/dtf/atoms'
 import { RESERVE_API } from '@/utils/constants'
-import { VoteLockPosition } from '@/views/earn/views/index-dtf/hooks/use-vote-lock-positions'
+import useVoteLockPositions, {
+  VoteLockPosition,
+} from '@/views/earn/views/index-dtf/hooks/use-vote-lock-positions'
+import { indexDtfs } from '@reserve-protocol/dtf-catalog'
 import { useQuery } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
 
-export const useVoteLockDAO = () => {
-  const indexDTF = useAtomValue(indexDTFAtom)
+// Catalog entries are keyed with mixed-case addresses — normalize once.
+const activeCatalogByChain: Record<number, Set<string>> = {}
+for (const [chainId, entries] of Object.entries(indexDtfs)) {
+  activeCatalogByChain[Number(chainId)] = new Set(
+    Object.values(entries)
+      .filter((dtf) => dtf.status === 'active')
+      .map((dtf) => dtf.address.toLowerCase())
+  )
+}
 
-  return useQuery({
-    queryKey: ['vote-lock-dao', indexDTF?.id],
+const isActiveCatalogDTF = (address: string, chainId: number) =>
+  !!activeCatalogByChain[chainId]?.has(address.toLowerCase())
+
+// The DAO (and its APR) belongs to the vote-lock token, not the DTF — one
+// stToken governs many DTFs. Listed DTFs read the same /dtf/daos list the
+// earn page uses so every surface shares one cached number; unlisted DTFs
+// (or a list that can't answer) keep the per-DTF endpoint — it stays keyed
+// by DTF address because sdk getVoteLockDao resolves DAOs that way — and
+// accept its per-URL cache split.
+export const useVoteLockDAO = (): VoteLockPosition | undefined => {
+  const indexDTF = useAtomValue(indexDTFAtom)
+  const chainId = indexDTF?.chainId
+  const stTokenAddress = indexDTF?.stToken?.id.toLowerCase()
+  const isListed =
+    !!indexDTF && isActiveCatalogDTF(indexDTF.id, indexDTF.chainId)
+
+  const listQuery = useVoteLockPositions({
+    enabled: isListed && !!stTokenAddress,
+  })
+  const listedDao = listQuery.data?.find(
+    (position) =>
+      position.chainId === chainId &&
+      position.token.address.toLowerCase() === stTokenAddress
+  )
+
+  const needsDetail =
+    !!stTokenAddress &&
+    (!isListed ||
+      listQuery.isError ||
+      (listQuery.isSuccess && !listedDao))
+  const daoQuery = useQuery({
+    queryKey: ['vote-lock-dao', indexDTF?.id, chainId],
     queryFn: async () => {
       const daoData = await fetch(
-        `${RESERVE_API}dtf/daos/${indexDTF?.id}?chainId=${indexDTF?.chainId}`
+        `${RESERVE_API}dtf/daos/${indexDTF?.id}?chainId=${chainId}`
       )
       if (!daoData.ok) {
-        throw new Error('Failed to fetch DTF daos')
+        throw new Error('Failed to fetch DTF dao')
       }
       const data = await daoData.json()
       return data as VoteLockPosition
     },
+    enabled: needsDetail,
   })
+
+  return listedDao ?? daoQuery.data
 }
 
 export const useVoteLockAPR = (): number | undefined => {
-  const { data: daoData } = useVoteLockDAO()
-
-  return daoData?.apr
+  return useVoteLockDAO()?.apr
 }

--- a/src/views/index-dtf/overview/hooks/use-staking-vault-apy.ts
+++ b/src/views/index-dtf/overview/hooks/use-staking-vault-apy.ts
@@ -42,11 +42,12 @@ export const useVoteLockDAO = (): VoteLockPosition | undefined => {
       position.token.address.toLowerCase() === stTokenAddress
   )
 
+  // Detail fallback: no answer in the shared list — the DTF is unlisted, or
+  // the list settled (success/error) without this DAO. A cached list hit
+  // counts as an answer even for unlisted DTFs; it's the same DAO row.
+  const listSettled = listQuery.isError || listQuery.isSuccess
   const needsDetail =
-    !!stTokenAddress &&
-    (!isListed ||
-      listQuery.isError ||
-      (listQuery.isSuccess && !listedDao))
+    !!stTokenAddress && !listedDao && (!isListed || listSettled)
   const daoQuery = useQuery({
     queryKey: ['vote-lock-dao', indexDTF?.id, chainId],
     queryFn: async () => {


### PR DESCRIPTION
## Problem

Each Index DTF overview page fetched its vote-lock APR from `/dtf/daos/{dtfAddress}` — a per-DTF URL cached 24h. The APR belongs to the vote-lock DAO (one vlRSR governs all the BSC AI DTFs), so the same number was being sampled at different times through different cache entries: BUILDOUT showed 53.19%, POWER 52.98%, and the earn page 45.73%.

## Fix

- DTFs that are active in `@reserve-protocol/dtf-catalog` (sync check, no fetch) now read the same `/dtf/daos` list query the earn page uses (`['vote-lock-positions']`) and pick their DAO by stToken address — every surface renders the same cached number by construction.
- Unlisted DTFs, or a list that can't answer (request error, DAO missing from the response), fall back to the existing per-DTF endpoint. That endpoint stays keyed by DTF address — `sdk.getVoteLockDao` resolves DAOs that way — so the residual cache split only applies to unlisted DTFs.
- Catalog addresses are normalized once at module init: two BSC entries are keyed with checksummed addresses, which a naive lowercase lookup misses.
- `useVoteLockPositions` gains an opt-in `enabled` option; default behavior on the earn page is unchanged.
- `useVoteLockDAO` now returns the position directly instead of a spread query result (keeps React Query's tracked-props render optimization).

Verified against the live API: BUILDOUT overview, POWER overview, and the earn page all render 46.83% APR from a single `/dtf/daos` request.

No reserve-api changes required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved vote-lock APR data retrieval with automatic fallback when list data is unavailable or incomplete.
  * Added conditional loading controls for vote-lock position data.

* **Bug Fixes**
  * Improved handling of inactive, unlisted, or mixed-case DTF addresses.
  * Ensured vote-lock APR displays correctly across supported DTFs.

* **Documentation**
  * Clarified DTF data endpoint fallback behavior.
  * Updated progress tracking and verification notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->