### PR TITLE
chore: remove odos zap provider references

### DIFF
--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -55,7 +55,7 @@ Base URL: `https://api.reserve.org`
 | `GET /v1/portfolio/:address` | Cross-DTF wallet balances | — | `src/views/portfolio-page/hooks/use-portfolio.ts` |
 | `GET /v1/historical/portfolio/:address` | Portfolio value history | `period` | `src/views/portfolio-page/hooks/use-historical-portfolio.ts` |
 
-**Price consensus**: 7 sources (Coinbase, CMC, Alchemy, DefiLlama, Odos, Moralis, internal). Cached ~60s with 30s stale-while-revalidate.
+**Price consensus**: 6 sources (Coinbase, CMC, Alchemy, DefiLlama, Moralis, internal). Cached ~60s with 30s stale-while-revalidate.
 
 **Important**: `/current/dtf` basket uses `Folio.toAssets(1e18, 0)` — rounding=0 is Floor. Only relevant to the legacy consumers above; the SDK snapshot hook does not use this endpoint.
 

--- a/docs/wiki/zapper.md
+++ b/docs/wiki/zapper.md
@@ -10,13 +10,13 @@ Three distinct mechanisms; don't mix them up. The CoW-suggestion card next to th
 
 ## 1. `@reserve-protocol/react-zapper` ([react-zapper](https://github.com/reserve-protocol/react-zapper)) — Index DTF instant zap
 
-Register pins the exact version (no caret) and wraps it in `src/views/index-dtf/components/zapper/zapper-wrapper.tsx` (also mutates `PROVIDER_ENABLED` to disable Odos on BSC, injects RainbowKit `connectWallet` and `locale`).
+Register pins the exact version (no caret) and wraps it in `src/views/index-dtf/components/zapper/zapper-wrapper.tsx` (injects RainbowKit `connectWallet` and `locale`).
 
 - **Locked settings for featured DTFs**: the wrapper passes `disabledSettings={{ deepLiquidity: true, forceMint: true }}` (prop added in 2.4.0) for the DTFs hardcoded in `locked-zap-settings.ts` (5 featured BSC DTFs from `/v1/discover/featured`: PHOTON, BUILDOUT, ROBOTS, POWER, NEOCLOUD). A disabled option renders its checkbox frozen unchecked (same treatment as the always-on dust checkbox) and the widget's updater force-resets the backing atom to `false` — including on SPA navigation from a DTF where the user had it checked.
 
 - **v2 contract**: the widget consumes the HOST's `WagmiProvider` + `QueryClientProvider` (the old `wagmiConfig` prop was removed in 2.0.0). Peer floors: wagmi ^2.19, viem ^2.50, react-query ^5.87.
 - **One instance per route — hard rule.** All widget state is module-level jotai atoms on the default store (no `Provider` isolation): two mounted `Zapper`s with different `chain`/`dtfAddress` fight last-writer-wins over shared atoms (`chainIdAtom`, `indexDTFAtom`, tab/modal atoms…). This caused register's real double-mount bug. Mounts: inline in `src/views/index-dtf/issuance/index.tsx`, modal in `index-dtf-container.tsx` — the modal mount is skipped on issuance routes on purpose. `useZapperModal()` shares the single instance.
-- **Quotes**: provider registry (`zap` native + odos/velora/enso aggregators); `best` queries all enabled in parallel, picks max `minAmountOut` (ties → zap). Native zap hits `ZAPPER_API`; aggregators hit `RESERVE_API`. Slippage/minAmountOut computed **server-side**. Refresh default 9s (`refreshRate` prop); quotes carry `validUntil` (~60s TTL).
+- **Quotes**: provider registry (`zap` native + velora/enso aggregators); `best` queries all enabled in parallel, picks max `minAmountOut` (ties → zap). Native zap hits `ZAPPER_API`; aggregators hit `RESERVE_API`. Slippage/minAmountOut computed **server-side**. Refresh default 9s (`refreshRate` prop); quotes carry `validUntil` (~60s TTL).
 - **Tx**: backend returns ready `{to,data,value}`; widget sends via host wagmi. Approval = 120% of amountIn; gas = min(backend×2-3, 2^24 EIP-7825 cap).
 - **Self-inits its own Mixpanel** with a hardcoded token (events `index-dtf-zap-swap`, `zap_*` clicks, contact events) — independent of register's analytics and not disableable; register's own zap events are additional.
 - Footguns: `dtfAddress` should be lowercase (<2.3.3 broke Sell balances on checksummed input); `styles.css`/Tailwind content path required; native token sentinel `0xEeee…EEeE`.

--- a/e2e/helpers/zapper.ts
+++ b/e2e/helpers/zapper.ts
@@ -13,7 +13,7 @@ import { loadSnapshot, loadSnapshotRaw, snapshotExists } from './snapshots'
 //
 //   native zap:  /api/zapper/{chainId}/swap?chainId&signer&tokenIn&amountIn
 //                  &tokenOut&slippage&trade&bypassCache&deepLiquidity
-//   aggregators: /{odos|velora|enso}/swap?chainId&tokenIn&tokenOut&amountIn
+//   aggregators: /{velora|enso}/swap?chainId&tokenIn&tokenOut&amountIn
 //                  &slippage&signer
 //
 // In its default "best" mode the widget fires ALL enabled providers in
@@ -136,7 +136,7 @@ export async function fillAmountAwaitQuote(
   }).toPass({ timeout: 90_000 })
 }
 
-const AGGREGATORS = ['odos', 'velora', 'enso'] as const
+const AGGREGATORS = ['velora', 'enso'] as const
 
 // Logger the zap specs hand to mockZapperRoutes: mirrors the base fixture's
 // collector — push into the test's `unmockedCalls` (so strict teardown fails on

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@reserve-protocol/dtf-chat": "^0.0.6",
     "@reserve-protocol/dtf-rebalance-lib": "^3.2.1",
     "@reserve-protocol/react-sdk": "0.5.0",
-    "@reserve-protocol/react-zapper": "2.7.1",
+    "@reserve-protocol/react-zapper": "2.8.0",
     "@reserve-protocol/rtokens": "^1.1.23",
     "@reserve-protocol/trusted-fillers-sdk": "^0.3.0",
     "@sentry/react": "^9.47.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 0.5.0
         version: 0.5.0(@tanstack/react-query@5.99.0(react@18.3.1))(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@reserve-protocol/react-zapper':
-        specifier: 2.7.1
-        version: 2.7.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(ajv@8.18.0)(multiformats@14.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
+        specifier: 2.8.0
+        version: 2.8.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(ajv@8.18.0)(multiformats@14.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
       '@reserve-protocol/rtokens':
         specifier: ^1.1.23
         version: 1.1.23
@@ -3247,8 +3247,8 @@ packages:
       react: ^18.3.1
       viem: ^2.48.0
 
-  '@reserve-protocol/react-zapper@2.7.1':
-    resolution: {integrity: sha512-6U7Wd4ixiGNBRXzDJ9E3JsskpdLUtgN8YdTcbJh5AskiPR5EV5TVLGhW5fSelcn065KnAdJHtFHCCUMT5oosMA==}
+  '@reserve-protocol/react-zapper@2.8.0':
+    resolution: {integrity: sha512-vMMY0fKjyuVo16kJWjWmHC77tfJAtcFshLHDl9WDXGxYYXdNjUqIA570YFAXueBoUlUJYVXvPuI0IzsEuWV2jw==}
     peerDependencies:
       '@tanstack/react-query': ^5.87.4
       react: ^18.3.1
@@ -11893,7 +11893,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reserve-protocol/react-zapper@2.7.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(ajv@8.18.0)(multiformats@14.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))':
+  '@reserve-protocol/react-zapper@2.8.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(ajv@8.18.0)(multiformats@14.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))':
     dependencies:
       '@cowprotocol/cow-sdk': 9.1.5(ajv@8.18.0)(cross-fetch@3.2.0)(multiformats@14.0.0)
       '@lucide/lab': 0.1.2
@@ -13266,7 +13266,7 @@ snapshots:
       '@noble/hashes': 1.7.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      uint8arrays: 3.1.0
+      uint8arrays: 3.1.1
 
   '@walletconnect/safe-json@1.0.2':
     dependencies:

--- a/src/views/index-dtf/components/zapper/zapper-wrapper.tsx
+++ b/src/views/index-dtf/components/zapper/zapper-wrapper.tsx
@@ -1,10 +1,5 @@
 import { useConnectModal } from '@rainbow-me/rainbowkit'
-import {
-  Zapper,
-  ZapperProps,
-  PROVIDER_ENABLED,
-} from '@reserve-protocol/react-zapper'
-import { bsc } from 'viem/chains'
+import { Zapper, ZapperProps } from '@reserve-protocol/react-zapper'
 import { useMemo } from 'react'
 import { useAccount } from 'wagmi'
 import { useAtomValue } from 'jotai'
@@ -21,11 +16,6 @@ import { hasLockedZapSettings } from './locked-zap-settings'
 const LOCKED_SETTINGS: ZapperProps['disabledSettings'] = {
   deepLiquidity: true,
   forceMint: true,
-}
-
-const bscProviders = PROVIDER_ENABLED[bsc.id]
-if (bscProviders) {
-  bscProviders.odos = false
 }
 
 type ZapperWrapperProps = ZapperProps

--- a/src/views/index-dtf/issuance/CLAUDE.md
+++ b/src/views/index-dtf/issuance/CLAUDE.md
@@ -43,7 +43,7 @@ Everything runs on **base/lcap** (`0x4dA9…E6e8`). Two different mock shapes:
 - **Zap surface**: `seedZapSurface(overrides, DTF)` seeds the folio's own
   name/symbol; `mockZapperRoutes(page, DTF, log)` serves ONE pinned quote per
   direction keyed on (chainId, tokenIn, tokenOut, amountIn) — **fill the exact
-  pinned `amountIn`** or you hit the fail-loud 500. Aggregators (odos/velora/
+  pinned `amountIn`** or you hit the fail-loud 500. Aggregators (velora/
   enso) answer a deterministic error on purpose so `best` mode has one
   candidate. `seedDtfBalance` funds the sell side + pre-answers the approve
   simulation. Assert the submitted tx equals the quote's `tx` byte-for-byte.

--- a/src/views/index-dtf/issuance/index.tsx
+++ b/src/views/index-dtf/issuance/index.tsx
@@ -13,15 +13,8 @@ import { wizardStepAtom } from './async-mint/atoms'
 import { panelModeAtom } from './atoms'
 import PanelModeSwitch from './panel-mode-switch'
 
-const DTF_DISABLED_FOR_ZAP = [] as string[]
-
 export const indexDTFQuoteSourceAtom = atom<ZapperProps['defaultSource']>(
-  (get) => {
-    // const dtf = get(indexDTFAtom)
-    // if (dtf?.id && DTF_DISABLED_FOR_ZAP.includes(dtf?.id.toLowerCase())) {
-    //   return 'odos'†
-    // }
-    // return 'best'
+  () => {
     return 'best'
   }
 )


### PR DESCRIPTION
Companion to react-zapper 2.8.0 (Odos removal — their API returned HTTP 410 "Service Ended").

- Removes the module-level `PROVIDER_ENABLED[bsc.id].odos = false` mutation in `zapper-wrapper.tsx`
  (the property no longer exists in 2.8.0 and would be a compile error after the bump).
- Deletes the dead commented `return 'odos'` quote-source block and its unused
  `DTF_DISABLED_FOR_ZAP` constant.
- Drops `odos` from the e2e aggregator mocks and updates wiki/docs (price consensus is 6 sources
  now that reserve-api dropped the odos label).

**Follow-up on this branch after react-zapper 2.8.0 is on npm:** bump
`"@reserve-protocol/react-zapper"` to `"2.8.0"` in package.json + `pnpm install`, commit as
`chore: bump react-zapper to 2.8.0`. The code here is forward-compatible with the current 2.7.1
pin, so CI stays green in the meantime.

Supersedes the open `devin/1784922531-bump-react-zapper-2.7.2` bump branch.

Verification: `pnpm typecheck` (app + e2e tsconfigs) clean, `pnpm lint` no new warnings,
`pnpm test:run` 840 passed, `pnpm e2e:smoke` 56 passed / 1 pre-existing skip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Price consensus now uses six sources, with Odos removed.
  - Zapper quotes now use native swaps, Velora, and Enso aggregators.
  - Odos is no longer available as a quote provider for documented zap flows.
  - Quote selection remains set to “best,” with existing caching, slippage, and minimum-output behavior unchanged.

- **Documentation**
  - Updated Zapper and data-source documentation to reflect the revised provider configuration.
  - Updated testing guidance for exact quote amounts in zap mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->