### PR TITLE
chore: disable enso zap provider

### DIFF
--- a/src/views/index-dtf/components/zapper/zapper-wrapper.tsx
+++ b/src/views/index-dtf/components/zapper/zapper-wrapper.tsx
@@ -1,5 +1,9 @@
 import { useConnectModal } from '@rainbow-me/rainbowkit'
-import { Zapper, ZapperProps } from '@reserve-protocol/react-zapper'
+import {
+  PROVIDER_ENABLED,
+  Zapper,
+  ZapperProps,
+} from '@reserve-protocol/react-zapper'
 import { useMemo } from 'react'
 import { useAccount } from 'wagmi'
 import { useAtomValue } from 'jotai'
@@ -12,6 +16,10 @@ import {
 } from '@/utils/schedule-call'
 import LargeMintPrompt from './large-mint-prompt'
 import { hasLockedZapSettings } from './locked-zap-settings'
+
+for (const providers of Object.values(PROVIDER_ENABLED)) {
+  if (providers) providers.enso = false
+}
 
 const LOCKED_SETTINGS: ZapperProps['disabledSettings'] = {
   deepLiquidity: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the Enso provider to prevent it from being offered while unavailable.
  * Updated provider availability handling for more reliable Zapper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->