### PR TITLE
Pin dtf-catalog to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@rainbow-me/rainbowkit": "^2.2.10",
     "@reserve-protocol/async-zap-sdk": "^0.8.0",
-    "@reserve-protocol/dtf-catalog": "^0.1.3",
+    "@reserve-protocol/dtf-catalog": "0.1.3",
     "@reserve-protocol/dtf-chat": "^0.0.6",
     "@reserve-protocol/dtf-rebalance-lib": "^3.2.1",
     "@reserve-protocol/react-sdk": "0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0(@tanstack/react-query@5.99.0(react@18.3.1))(ajv@8.18.0)(cross-fetch@4.1.0)(multiformats@14.0.0)(react@18.3.1)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
       '@reserve-protocol/dtf-catalog':
-        specifier: ^0.1.3
+        specifier: 0.1.3
         version: 0.1.3
       '@reserve-protocol/dtf-chat':
         specifier: ^0.0.6


### PR DESCRIPTION
Pins `@reserve-protocol/dtf-catalog` to exactly `0.1.3` (was `^0.1.3`).

The next catalog release adds MAG7, which isn't publicly launched yet. The lockfile already resolves 0.1.3, but the caret meant any `pnpm update` or lockfile regen would pull the new version and leak the unreleased DTF into the list. Exact pin keeps that a deliberate bump — which doubles as the launch switch. reserve-api already pins exact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Locked the DTF Catalog package to version 0.1.3 for more consistent builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->