### PR TITLE
fix(governance): contain long voting modal titles

### DIFF
--- a/docs/wiki/domains/design-system.md
+++ b/docs/wiki/domains/design-system.md
@@ -1,6 +1,6 @@
 ---
 title: Design System
-updated: 2026-07-02
+updated: 2026-08-07
 type: domain
 sources:
   - tailwind.config.ts

--- a/docs/wiki/progress.md
+++ b/docs/wiki/progress.md
@@ -1,6 +1,6 @@
 ---
 title: Progress
-updated: 2026-07-31
+updated: 2026-08-07
 type: ledger
 ---
 
@@ -10,6 +10,7 @@ Stage ledger. One row per stage; keep entries short. Verifier = exact fresh comm
 
 | Stage | Status | Verifier | Review | Next |
 |---|---|---|---|---|
+| Fix voting modal title overflow | done (base 6854a370b; low: security hint is e2e-fixture-only) | RED: long-title browser bound false; GREEN: vote flow desktop 2/2 + mobile 1/1 · scoped lint/typecheck + 851 unit + 72 helper + 58 smoke · wiki-lint | correctness/product: self-review pass; local `break-all`, desktop+mobile browser bounds, settled visual edge check | — |
 | vlRSR self-appreciating vaults: drawer shares/redeem + rate line · governance card · portfolio · earn rate-corrected + APY | human-review-required (base d0427a7cf; SDK local-linked) | gate green: typecheck+lint+847 unit · 72 helper · smoke 58 · drawer spec 2/2 · live BSC visual light+dark incl. earn TVL 261.5M RSR = totalAssets | Dark + Light on both diffs; all blockers fixed; details in git | PR #1072 open on SDK 0.5.1 (published, pinned exact; direct sdk dep dropped). Companions: dtf-interface#29, reserve-api#236 (deploy w/ daos CDN purge). **Engineer review**: withdraw→redeem for ALL vaults, governance card, api token.price×rate. [plan](../plans/vlrsr-self-appreciating-vaults.md) |
 | focused-tab automatic chain switching | human-review-required (base b2fcf72c6) | lint/typecheck · unit 840 incl. 8 focus/visibility · helpers 70 · smoke 56 + 1 skipped · wiki-lint | Dark + Light: stale Index target + mutation-boundary focus recheck fixed; automatic switching preserved, background tabs passive | Engineer review wallet/chain flow; then ship |
 | vote-lock APR unified on /dtf/daos list | done (base 771c92873) | gate-equivalent green (lint/typecheck/unit, 70 helper, 56 smoke, wiki-lint) · live visual: BUILDOUT + POWER overviews and earn all 46.83% from one list request | Dark + Light, per-claim verify — adopted: list-miss/error fallback gating, plain-data return, catalog mixed-case normalization; API re-key REVERTED by Luis (sdk `getVoteLockDao` needs the DTF-address key); accepted: unlisted DTFs keep per-DTF detail cache split | pre-existing reserve-api debt flagged, not shipped: maxAge-before-await caches 500s 24h; unguarded `underlyingPrice.price` deref can 500 whole list |

--- a/e2e/tests/flows/governance-vote.spec.ts
+++ b/e2e/tests/flows/governance-vote.spec.ts
@@ -35,6 +35,48 @@ function loadProposal(): ProposalSnapshot {
   return loadSnapshot<ProposalSnapshot>(`${dtf.snapshotDir}/proposals/${PROPOSAL_ID}.json`)
 }
 
+test('keeps a long proposal title inside the voting modal @mobile', async ({
+  page,
+  overrides,
+}) => {
+  const dtf = findDtfByAddress(DTF_ADDRESS)!
+  const { proposal } = loadProposal()
+  const overlay = loadEnrichedProposal(PROPOSAL_ID)!
+  const { dtf: dtfSnapshot } = loadSnapshot<{ dtf: Record<string, unknown> }>(
+    `${dtf.snapshotDir}/dtf.json`
+  )
+  const longTitle =
+    '# "Add 0xb3CF59A5f12cA319861376C5e63Eef4790a42B44 as an optimistic proposer"'
+
+  overrides.subgraph(
+    {
+      operationName: 'GetIndexDtfProposal',
+      variables: { proposalId: PROPOSAL_ID },
+    },
+    {
+      dtf: dtfSnapshot,
+      proposal: { ...overlay.proposal, description: longTitle },
+    }
+  )
+  await freezeTime(page, proposalTime(proposal, 'active'))
+  await page.goto(dtfPath(dtf, `governance/proposal/${PROPOSAL_ID}`))
+  await connectWallet(page)
+  await advanceTime(page, 5_000)
+  await page.getByTestId('proposal-vote-btn').click()
+
+  const dialog = page.getByRole('dialog')
+  const title = page.getByTestId('vote-proposal-title')
+  await expect(title).toBeVisible()
+  await expect
+    .poll(async () => {
+      const dialogBox = await dialog.boundingBox()
+      const titleBox = await title.boundingBox()
+      if (!dialogBox || !titleBox) return false
+      return titleBox.x + titleBox.width <= dialogBox.x + dialogBox.width
+    })
+    .toBe(true)
+})
+
 test('cast a For vote through the full transaction flow', async ({
   page,
   overrides,

--- a/src/views/index-dtf/governance/views/proposal/components/vote-modal.tsx
+++ b/src/views/index-dtf/governance/views/proposal/components/vote-modal.tsx
@@ -133,7 +133,10 @@ const VoteModal = (props: ModalProps) => {
       {!isOptimistic && (
         <>
           <div className="flex flex-col items-center">
-            <span className="text-xl font-medium">
+            <span
+              data-testid="vote-proposal-title"
+              className="w-full break-all text-center text-xl font-medium"
+            >
               "
               {proposal?.description ? (
                 getProposalTitle(proposal.description)


### PR DESCRIPTION
## Summary
- wrap long unbroken proposal titles inside the voting modal
- keep title alignment and shared modal defaults unchanged
- add desktop and mobile browser regression coverage for address-length titles

## Test plan
- `pnpm exec playwright test --project=full e2e/tests/flows/governance-vote.spec.ts`
- `pnpm exec playwright test --project=mobile e2e/tests/flows/governance-vote.spec.ts --grep "long proposal title"`
- scoped gate: lint, typecheck, 851 unit tests, 72 e2e helper tests, 58 smoke tests
- `node scripts/llm-workflow/wiki-lint.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voting modal titles so long proposal names stay within the dialog on mobile devices.

* **Tests**
  * Added mobile coverage to verify long voting proposal titles display correctly during active voting.

* **Documentation**
  * Updated design system and project progress documentation dates and recorded the voting modal fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->